### PR TITLE
Improve Result type contracts, misuse diagnostics, and error accumulation API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,17 @@ jobs:
 
       - name: Run PHP 8.1 compatibility check
         run: composer compat
+
+  syntax-check:
+    runs-on: ubuntu-latest
+    name: PHP 8.1 Syntax Check
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+
+      - name: Run PHP 8.1 syntax check
+        run: find src -name '*.php' -print0 | xargs -0 -n1 -P4 php -l

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `Result::accumulate2()` through `Result::accumulate9()` for combining multiple Results with error accumulation
 
+### Changed
+- Changed `flatMap()` type definitions to preserve the original error type as `E|E1` instead of dropping `E`
+
 ## [0.2.1] - 2026-02-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `flatMap()` type definitions to preserve the original error type as `E|E1` instead of dropping `E`
 - Changed `recover()` and `recoverWith()` type definitions to allow different recovery success types
 - Changed `recover()` type definitions to return `never` as the error type after successful recovery
+- Changed `flatten()` type definitions to preserve nested success and error types
 
 ### Fixed
 - Fixed `Result::binding()` hanging forever when a generator yields a non-Result value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `recover()` type definitions to return `never` as the error type after successful recovery
 - Changed `flatten()` type definitions to preserve nested success and error types
 - Changed unreleased `Result::accumulate2()` through `Result::accumulate9()` APIs to accept Result instances directly instead of callables
+- Improved non-Throwable `Failure::get()` exception messages by including the error value type
 
 ### Fixed
 - Fixed `Result::binding()` hanging forever when a generator yields a non-Result value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `Result::accumulate2()` through `Result::accumulate9()` for combining multiple Results with error accumulation
-- `Result::sequence()` for converting a list of Results into one Result while collecting all errors
+- `Result::accumulate2()` through `Result::accumulate9()` for combining multiple Result instances with error accumulation
+- `Result::accumulate()` for converting a list of Results into one Result while collecting all errors; throws `ResultException` if any element is not a Result instance
 
 ### Changed
-- Changed `flatMap()` type definitions to preserve the original error type as `E|E1` instead of dropping `E`
-- Changed `recover()` and `recoverWith()` type definitions to allow different recovery success types
-- Changed `recover()` type definitions to return `never` as the error type after successful recovery
-- Changed `flatten()` type definitions to preserve nested success and error types
-- Changed unreleased `Result::accumulate2()` through `Result::accumulate9()` APIs to accept Result instances directly instead of callables
-- Improved non-Throwable `Failure::get()` exception messages by including the error value type
+- Changed `flatMap()` type signature to preserve the original error type
+  - Before: `@return Result<T1, E1>`
+  - After: `@return Result<T1, E|E1>`
+- Changed `recover()` type signature to allow a different recovery success type and return `never` as the error type
+  - Before: `@param callable(E): T $fn` / `@return Result<T, E>`
+  - After: `@param callable(E): T1 $fn` / `@return Result<T|T1, never>`
+- Changed `recoverWith()` type signature to allow a different recovery success type
+  - Before: `@param callable(E): Result<T, E1> $fn` / `@return Result<T, E1>`
+  - After: `@param callable(E): Result<T1, E1> $fn` / `@return Result<T|T1, E1>`
+- Changed `flatten()` type signature to preserve nested success and error types instead of widening to `mixed`
+  - Before: `@return Result<mixed, mixed>`
+  - After: `@return Result<T, E>` unchanged, or `Result<TInner, E|EInner>` if the success value is a `Result<TInner, EInner>`
+- Improved `Failure::get()` (non-Throwable errors) and `Success::getError()` exception messages by including the value's type
 
 ### Fixed
-- Fixed `Result::binding()` hanging forever when a generator yields a non-Result value
+- Fixed `Result::binding()` hanging forever when a generator yields a non-Result value — it now throws `ResultException` instead
+- Fixed `Result::binding()` throwing an unclear PHP error when the callable does not return a `Generator` — it now throws `ResultException` with a descriptive message
 
 ## [0.2.1] - 2026-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `Result::accumulate2()` through `Result::accumulate9()` for combining multiple Results with error accumulation
+- `Result::sequence()` for converting a list of Results into one Result while collecting all errors
 
 ### Changed
 - Changed `flatMap()` type definitions to preserve the original error type as `E|E1` instead of dropping `E`
 - Changed `recover()` and `recoverWith()` type definitions to allow different recovery success types
 - Changed `recover()` type definitions to return `never` as the error type after successful recovery
 - Changed `flatten()` type definitions to preserve nested success and error types
+- Changed unreleased `Result::accumulate2()` through `Result::accumulate9()` APIs to accept Result instances directly instead of callables
 
 ### Fixed
 - Fixed `Result::binding()` hanging forever when a generator yields a non-Result value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changed `flatMap()` type definitions to preserve the original error type as `E|E1` instead of dropping `E`
 
+### Fixed
+- Fixed `Result::binding()` hanging forever when a generator yields a non-Result value
+
 ## [0.2.1] - 2026-02-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changed `flatMap()` type definitions to preserve the original error type as `E|E1` instead of dropping `E`
+- Changed `recover()` and `recoverWith()` type definitions to allow different recovery success types
+- Changed `recover()` type definitions to return `never` as the error type after successful recovery
 
 ### Fixed
 - Fixed `Result::binding()` hanging forever when a generator yields a non-Result value

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # php-result
 
-Type-safe Result type library for PHP 8.2+ with PHPStan support.
+Type-safe Result type library for PHP 8.1+ (dev tooling requires PHP 8.2+) with PHPStan support.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ $value = $result->getOrNull(); // T|null
 // Flatten nested Results
 $nested = Result::success(Result::success(42));
 $flat = $nested->flatten(); // Success(42)
+// Result<Result<int, string>, string> becomes Result<int, string>.
 
 // Monad comprehension with binding (avoids nested flatMap)
 $result = Result::binding(function () use ($orderId) {
@@ -162,6 +163,18 @@ $recovered = $result->recover(fn(string $error) => false);
 ```
 
 After `recover()`, the Result can no longer be a Failure. `recoverWith()` keeps the callback's error type because the fallback operation may still fail.
+
+### Flattening Nested Results
+
+`flatten()` preserves nested generic types. If the success value is another `Result`, the inner success type is used and the outer and inner error types are combined:
+
+```php
+/** @var Result<Result<int, DbError>, ValidationError> $result */
+$flat = $result->flatten();
+// Result<int, ValidationError|DbError>
+```
+
+Calling `flatten()` on a non-nested Result keeps the original type.
 
 ## PHPStan Integration
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $message = $result->fold(
 $result = validateEmail($input['email'])
     ->flatMap(fn($email) => validatePassword($input['password'])
     ->flatMap(fn($password) => createUser($email, $password)));
+// If each step can fail differently, the error type is the union of all possible errors.
 
 // Recover from failure with default value
 $recovered = $failure->recover(fn($e) => 'default'); // Success('default')
@@ -135,6 +136,18 @@ $result = Result::accumulate3(
 | `tapError($fn)` | Execute side effect on error value, return same Result |
 | `getOrNull()` | Get success value or null |
 | `flatten()` | Flatten nested `Result<Result<T, E>, E>` into `Result<T, E>` |
+
+### Error Types in flatMap
+
+`flatMap()` preserves both the original error type and the error type returned by the callback:
+
+```php
+/** @var Result<string, ValidationError> $result */
+$saved = $result->flatMap(fn(string $value) => save($value));
+// If save() returns Result<User, DbError>, $saved is Result<User, ValidationError|DbError>.
+```
+
+Long chains can naturally produce wide error unions. When that becomes awkward, normalize errors with `mapError()` to a domain-specific error type at a boundary.
 
 ## PHPStan Integration
 
@@ -232,4 +245,3 @@ return match (true) {
 ```
 
 The custom rule in this library ensures exhaustiveness, so it's safe to ignore `match.unhandled` for Result types.
-

--- a/README.md
+++ b/README.md
@@ -89,11 +89,20 @@ $result = Result::binding(function () use ($orderId) {
 // Returns Result<list<Item>, Throwable> - short-circuits on first failure
 // Every yielded value must be a Result; invalid yields throw ResultException.
 
+// Sequence a list of Results, collecting all errors
+$result = Result::sequence([
+    validateName($input['name']),
+    validateAge($input['age']),
+    validateEmail($input['email']),
+]);
+// All Success → Success([name, age, email])
+// Any Failure → Failure(['Name required', 'Invalid email']) (non-empty-list of errors)
+
 // Accumulate errors from multiple independent validations
 $result = Result::accumulate3(
-    fn() => validateName($input['name']),
-    fn() => validateAge($input['age']),
-    fn() => validateEmail($input['email']),
+    validateName($input['name']),
+    validateAge($input['age']),
+    validateEmail($input['email']),
     fn(string $name, int $age, string $email) => new User($name, $age, $email)
 );
 // All Success → Success(User(...))
@@ -110,14 +119,15 @@ $result = Result::accumulate3(
 | `Result::failure($error)` | Create a Failure |
 | `Result::catch(callable $fn)` | Wrap exception-throwing code |
 | `Result::binding(callable $fn)` | Monad comprehension using generators |
-| `Result::accumulate2($fn1, ..., $transform)` | Combine 2 Results, collecting all errors |
-| `Result::accumulate3($fn1, ..., $transform)` | Combine 3 Results, collecting all errors |
-| `Result::accumulate4($fn1, ..., $transform)` | Combine 4 Results, collecting all errors |
-| `Result::accumulate5($fn1, ..., $transform)` | Combine 5 Results, collecting all errors |
-| `Result::accumulate6($fn1, ..., $transform)` | Combine 6 Results, collecting all errors |
-| `Result::accumulate7($fn1, ..., $transform)` | Combine 7 Results, collecting all errors |
-| `Result::accumulate8($fn1, ..., $transform)` | Combine 8 Results, collecting all errors |
-| `Result::accumulate9($fn1, ..., $transform)` | Combine 9 Results, collecting all errors |
+| `Result::sequence($results)` | Convert a list of Results into one Result, collecting all errors |
+| `Result::accumulate2($r1, ..., $transform)` | Combine 2 Results, collecting all errors |
+| `Result::accumulate3($r1, ..., $transform)` | Combine 3 Results, collecting all errors |
+| `Result::accumulate4($r1, ..., $transform)` | Combine 4 Results, collecting all errors |
+| `Result::accumulate5($r1, ..., $transform)` | Combine 5 Results, collecting all errors |
+| `Result::accumulate6($r1, ..., $transform)` | Combine 6 Results, collecting all errors |
+| `Result::accumulate7($r1, ..., $transform)` | Combine 7 Results, collecting all errors |
+| `Result::accumulate8($r1, ..., $transform)` | Combine 8 Results, collecting all errors |
+| `Result::accumulate9($r1, ..., $transform)` | Combine 9 Results, collecting all errors |
 
 ### Instance Methods
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ A type-safe Result type for PHP 8.1+ with PHPStan support.
 composer require jsoizo/php-result
 ```
 
+## Requirements
+
+The library runtime supports PHP 8.1+. The development and test tooling in this repository requires PHP 8.2+ because the locked Pest/PHPUnit toolchain requires PHP 8.2.
+
 ## Basic Usage
 
 ```php
@@ -282,3 +286,7 @@ return match (true) {
 ```
 
 The custom rule in this library ensures exhaustiveness, so it's safe to ignore `match.unhandled` for Result types.
+
+**Limitations:**
+
+The custom rule tracks simple variables in `instanceof` match arms, such as `$result instanceof Success`. It intentionally does not check property fetches or method calls such as `$this->result instanceof Success` or `$this->getResult() instanceof Success`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ $result = validateEmail($input['email'])
 
 // Recover from failure with default value
 $recovered = $failure->recover(fn($e) => 'default'); // Success('default')
+// recover() always returns a successful Result, so the error type becomes never.
 
 // Chain fallback operations
 $result = fetchFromPrimaryDb()
@@ -149,6 +150,18 @@ $saved = $result->flatMap(fn(string $value) => save($value));
 ```
 
 Long chains can naturally produce wide error unions. When that becomes awkward, normalize errors with `mapError()` to a domain-specific error type at a boundary.
+
+### Recovering with Different Success Types
+
+`recover()` and `recoverWith()` can return a different success type than the original `Result`:
+
+```php
+/** @var Result<int, string> $result */
+$recovered = $result->recover(fn(string $error) => false);
+// Result<int|bool, never>
+```
+
+After `recover()`, the Result can no longer be a Failure. `recoverWith()` keeps the callback's error type because the fallback operation may still fail.
 
 ## PHPStan Integration
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ $result = Result::binding(function () use ($orderId) {
 // Returns Result<list<Item>, Throwable> - short-circuits on first failure
 // Every yielded value must be a Result; invalid yields throw ResultException.
 
-// Sequence a list of Results, collecting all errors
-$result = Result::sequence([
+// Accumulate a list of Results into one, collecting all errors
+$result = Result::accumulate([
     validateName($input['name']),
     validateAge($input['age']),
     validateEmail($input['email']),
@@ -113,6 +113,8 @@ $result = Result::accumulate3(
 // Any Failure → Failure(['Name required', 'Invalid email']) (non-empty-list of errors)
 ```
 
+Use `accumulate($results)` for a homogeneous list of same-typed Results; use `accumulate2()`–`accumulate9()` to combine differently-typed Results into one value via a transform function.
+
 ## API
 
 ### Factory Methods
@@ -123,7 +125,7 @@ $result = Result::accumulate3(
 | `Result::failure($error)` | Create a Failure |
 | `Result::catch(callable $fn)` | Wrap exception-throwing code |
 | `Result::binding(callable $fn)` | Monad comprehension using generators |
-| `Result::sequence($results)` | Convert a list of Results into one Result, collecting all errors |
+| `Result::accumulate($results)` | Convert a list of Results into one Result, collecting all errors |
 | `Result::accumulate2($r1, ..., $transform)` | Combine 2 Results, collecting all errors |
 | `Result::accumulate3($r1, ..., $transform)` | Combine 3 Results, collecting all errors |
 | `Result::accumulate4($r1, ..., $transform)` | Combine 4 Results, collecting all errors |
@@ -152,7 +154,7 @@ $result = Result::accumulate3(
 | `tap($fn)` | Execute side effect on success value, return same Result |
 | `tapError($fn)` | Execute side effect on error value, return same Result |
 | `getOrNull()` | Get success value or null |
-| `flatten()` | Flatten nested `Result<Result<T, E>, E>` into `Result<T, E>` |
+| `flatten()` | Flatten nested `Result<Result<T, E1>, E2>` into `Result<T, E1\|E2>` |
 
 ### Error Types in flatMap
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ $result = Result::binding(function () use ($orderId) {
     return $items;
 });
 // Returns Result<list<Item>, Throwable> - short-circuits on first failure
+// Every yielded value must be a Result; invalid yields throw ResultException.
 
 // Accumulate errors from multiple independent validations
 $result = Result::accumulate3(

--- a/src/Failure.php
+++ b/src/Failure.php
@@ -238,9 +238,15 @@ final class Failure extends Result
     /**
      * {@inheritDoc}
      *
-     * For Failure, returns this Failure unchanged.
+     * For Failure, returns this Failure unchanged. The success value can never
+     * be a Result, so the type stays consistent with the abstract declaration.
      *
-     * @return Failure<T, E> This Failure
+     * @return (T is never
+     *     ? Result<never, E>
+     *     : (T is \Jsoizo\Result\Result<*, *>
+     *         ? \Jsoizo\Result\Result<template-type<T, \Jsoizo\Result\Result, 'T'>, E|template-type<T, \Jsoizo\Result\Result, 'E'>>
+     *         : Result<T, E>))
+     * @phpstan-ignore conditionalType.alwaysFalse (never is a subtype of every type, so the outer branch must stay reachable for narrowed T)
      */
     public function flatten(): Result
     {

--- a/src/Failure.php
+++ b/src/Failure.php
@@ -75,7 +75,7 @@ final class Failure extends Result
         if ($this->error instanceof \Throwable) {
             throw $this->error;
         }
-        throw new ResultException('Result is a failure');
+        throw new ResultException('Result is a failure: ' . get_debug_type($this->error));
     }
 
     /**

--- a/src/Failure.php
+++ b/src/Failure.php
@@ -170,14 +170,13 @@ final class Failure extends Result
      *
      * Applies the function to the contained error and wraps the result in a new Success.
      *
-     * @param callable(E): T $fn The recovery function
-     * @return Success<T, E> A new Success containing the recovered value
-     *
-     * @phpstan-ignore generics.variance (T is covariant but used in contravariant position in callable parameter for practical API design)
+     * @template U The type of the recovery value
+     * @param callable(E): U $fn The recovery function
+     * @return Success<U, never> A new Success containing the recovered value
      */
     public function recover(callable $fn): Success
     {
-        /** @var Success<T, E> */
+        /** @var Success<U, never> */
         return new Success($fn($this->error));
     }
 
@@ -186,11 +185,10 @@ final class Failure extends Result
      *
      * Applies the function to the contained error and returns the resulting Result directly.
      *
+     * @template U The success type of the resulting Result
      * @template E1 The error type of the resulting Result
-     * @param callable(E): Result<T, E1> $fn The recovery function returning a new Result
-     * @return Result<T, E1> The Result returned by the function
-     *
-     * @phpstan-ignore generics.variance (T is covariant but used in contravariant position in callable parameter for practical API design)
+     * @param callable(E): Result<U, E1> $fn The recovery function returning a new Result
+     * @return Result<U, E1> The Result returned by the function
      */
     public function recoverWith(callable $fn): Result
     {

--- a/src/Failure.php
+++ b/src/Failure.php
@@ -117,7 +117,7 @@ final class Failure extends Result
      * @template U The success type of the resulting Result (unused)
      * @template F The error type of the resulting Result (unused)
      * @param callable(T): Result<U, F> $fn The function (not called)
-     * @return Result<U, F> This Failure instance (type-widened for compatibility)
+     * @return Result<U, E|F> This Failure instance (type-widened for compatibility)
      */
     public function flatMap(callable $fn): Result
     {

--- a/src/Result.php
+++ b/src/Result.php
@@ -511,7 +511,7 @@ abstract class Result
      * @template T1 The success type of the resulting Result
      * @template E1 The error type of the resulting Result
      * @param callable(T): Result<T1, E1> $fn The function returning a new Result
-     * @return Result<T1, E1> The Result from the function, or the original Failure
+     * @return Result<T1, E|E1> The Result from the function, or the original Failure
      */
     abstract public function flatMap(callable $fn): Result;
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -94,10 +94,18 @@ abstract class Result
      * @template TError The error type
      * @param callable(): \Generator<int, Result<mixed, TError>, mixed, TValue> $fn
      * @return Result<TValue, TError>
+     * @throws ResultException If $fn does not return a Generator, or the generator yields a non-Result value
      */
     public static function binding(callable $fn): Result
     {
         $generator = $fn();
+
+        // @phpstan-ignore instanceof.alwaysTrue (guards callables that violate the PHPDoc return type at runtime)
+        if (!$generator instanceof \Generator) {
+            throw new ResultException(
+                'binding() callable must return a Generator, got: ' . get_debug_type($generator)
+            );
+        }
 
         while ($generator->valid()) {
             $result = $generator->current();
@@ -130,14 +138,22 @@ abstract class Result
      * @template E1
      * @param list<Result<T1, E1>> $results
      * @return Result<list<T1>, non-empty-list<E1>>
+     * @throws ResultException If any element of $results is not a Result instance
      */
-    public static function sequence(array $results): Result
+    public static function accumulate(array $results): Result
     {
         $values = [];
         $errors = [];
 
         foreach ($results as $result) {
-            if ($result instanceof Failure) {
+            // @phpstan-ignore instanceof.alwaysTrue (guards list elements that violate the PHPDoc param type at runtime)
+            if (!$result instanceof Result) {
+                throw new ResultException(
+                    'accumulate() expects Result instances, got: ' . get_debug_type($result)
+                );
+            }
+
+            if ($result->isFailure()) {
                 $errors[] = $result->getError();
 
                 continue;
@@ -147,11 +163,9 @@ abstract class Result
         }
 
         if ($errors !== []) {
-            /** @var non-empty-list<E1> $errors */
             return self::failure($errors);
         }
 
-        /** @var list<T1> $values */
         return self::success($values);
     }
 
@@ -176,7 +190,6 @@ abstract class Result
         $errors = self::collectErrors($r1, $r2);
 
         if ($errors !== []) {
-            /** @var non-empty-list<E1> $errors */
             return self::failure($errors);
         }
 
@@ -202,7 +215,6 @@ abstract class Result
         $errors = self::collectErrors($r1, $r2, $r3);
 
         if ($errors !== []) {
-            /** @var non-empty-list<E1> $errors */
             return self::failure($errors);
         }
 
@@ -230,7 +242,6 @@ abstract class Result
         $errors = self::collectErrors($r1, $r2, $r3, $r4);
 
         if ($errors !== []) {
-            /** @var non-empty-list<E1> $errors */
             return self::failure($errors);
         }
 
@@ -260,7 +271,6 @@ abstract class Result
         $errors = self::collectErrors($r1, $r2, $r3, $r4, $r5);
 
         if ($errors !== []) {
-            /** @var non-empty-list<E1> $errors */
             return self::failure($errors);
         }
 
@@ -292,7 +302,6 @@ abstract class Result
         $errors = self::collectErrors($r1, $r2, $r3, $r4, $r5, $r6);
 
         if ($errors !== []) {
-            /** @var non-empty-list<E1> $errors */
             return self::failure($errors);
         }
 
@@ -326,7 +335,6 @@ abstract class Result
         $errors = self::collectErrors($r1, $r2, $r3, $r4, $r5, $r6, $r7);
 
         if ($errors !== []) {
-            /** @var non-empty-list<E1> $errors */
             return self::failure($errors);
         }
 
@@ -362,7 +370,6 @@ abstract class Result
         $errors = self::collectErrors($r1, $r2, $r3, $r4, $r5, $r6, $r7, $r8);
 
         if ($errors !== []) {
-            /** @var non-empty-list<E1> $errors */
             return self::failure($errors);
         }
 
@@ -400,7 +407,6 @@ abstract class Result
         $errors = self::collectErrors($r1, $r2, $r3, $r4, $r5, $r6, $r7, $r8, $r9);
 
         if ($errors !== []) {
-            /** @var non-empty-list<E1> $errors */
             return self::failure($errors);
         }
 
@@ -607,9 +613,12 @@ abstract class Result
      * If the success value is not a Result, returns this Result unchanged.
      * For Failure, returns the Failure unchanged.
      *
-     * @return (T is \Jsoizo\Result\Result<*, *>
-     *     ? \Jsoizo\Result\Result<template-type<T, \Jsoizo\Result\Result, 'T'>, E|template-type<T, \Jsoizo\Result\Result, 'E'>>
-     *     : Result<T, E>)
+     * @return (T is never
+     *     ? Result<never, E>
+     *     : (T is \Jsoizo\Result\Result<*, *>
+     *         ? \Jsoizo\Result\Result<template-type<T, \Jsoizo\Result\Result, 'T'>, E|template-type<T, \Jsoizo\Result\Result, 'E'>>
+     *         : Result<T, E>))
+     * @phpstan-ignore conditionalType.alwaysFalse (never is a subtype of every type, so the outer branch must stay reachable for narrowed T)
      */
     abstract public function flatten(): Result;
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -562,10 +562,9 @@ abstract class Result
      * If this is a Failure, applies the function to the error and wraps the result
      * in a new Success. If this is a Success, returns the Success unchanged.
      *
-     * @param callable(E): T $fn The recovery function
-     * @return Result<T, E> A new Success with the recovered value, or the original Success
-     *
-     * @phpstan-ignore generics.variance (T is covariant but used in contravariant position in callable parameter for practical API design)
+     * @template T1 The type of the recovery value
+     * @param callable(E): T1 $fn The recovery function
+     * @return Result<T|T1, never> A new Success with the recovered value, or the original Success
      */
     abstract public function recover(callable $fn): Result;
 
@@ -576,11 +575,10 @@ abstract class Result
      * resulting Result directly. If this is a Success, returns the Success unchanged.
      * This allows chaining fallback operations or changing the error type.
      *
+     * @template T1 The success type of the resulting Result
      * @template E1 The error type of the resulting Result
-     * @param callable(E): Result<T, E1> $fn The recovery function returning a new Result
-     * @return Result<T, E1> The Result from the function, or the original Success
-     *
-     * @phpstan-ignore generics.variance (T is covariant but used in contravariant position in callable parameter for practical API design)
+     * @param callable(E): Result<T1, E1> $fn The recovery function returning a new Result
+     * @return Result<T|T1, E1> The Result from the function, or the original Success
      */
     abstract public function recoverWith(callable $fn): Result;
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -120,9 +120,45 @@ abstract class Result
     }
 
     /**
+     * Converts a list of Results into a Result containing a list of values.
+     *
+     * Collects every error instead of short-circuiting. If every Result is a
+     * Success, returns a Success with values in input order. If any Result is a
+     * Failure, returns a Failure with all errors in input order.
+     *
+     * @template T1
+     * @template E1
+     * @param list<Result<T1, E1>> $results
+     * @return Result<list<T1>, non-empty-list<E1>>
+     */
+    public static function sequence(array $results): Result
+    {
+        $values = [];
+        $errors = [];
+
+        foreach ($results as $result) {
+            if ($result instanceof Failure) {
+                $errors[] = $result->getError();
+
+                continue;
+            }
+
+            $values[] = $result->get();
+        }
+
+        if ($errors !== []) {
+            /** @var non-empty-list<E1> $errors */
+            return self::failure($errors);
+        }
+
+        /** @var list<T1> $values */
+        return self::success($values);
+    }
+
+    /**
      * Combines two Results, collecting all errors on failure.
      *
-     * Executes all callables and collects their Results. If all are Success,
+     * Evaluates all Results without short-circuiting. If all are Success,
      * applies the transform function to their values and returns a Success.
      * If any are Failure, collects all errors into a non-empty list.
      *
@@ -130,16 +166,13 @@ abstract class Result
      * @template T2
      * @template E1
      * @template U
-     * @param callable(): Result<T1, E1> $fn1
-     * @param callable(): Result<T2, E1> $fn2
+     * @param Result<T1, E1> $r1
+     * @param Result<T2, E1> $r2
      * @param callable(T1, T2): U $transform
      * @return Result<U, non-empty-list<E1>>
      */
-    public static function accumulate2(callable $fn1, callable $fn2, callable $transform): Result
+    public static function accumulate2(Result $r1, Result $r2, callable $transform): Result
     {
-        $r1 = $fn1();
-        $r2 = $fn2();
-
         $errors = self::collectErrors($r1, $r2);
 
         if ($errors !== []) {
@@ -158,18 +191,14 @@ abstract class Result
      * @template T3
      * @template E1
      * @template U
-     * @param callable(): Result<T1, E1> $fn1
-     * @param callable(): Result<T2, E1> $fn2
-     * @param callable(): Result<T3, E1> $fn3
+     * @param Result<T1, E1> $r1
+     * @param Result<T2, E1> $r2
+     * @param Result<T3, E1> $r3
      * @param callable(T1, T2, T3): U $transform
      * @return Result<U, non-empty-list<E1>>
      */
-    public static function accumulate3(callable $fn1, callable $fn2, callable $fn3, callable $transform): Result
+    public static function accumulate3(Result $r1, Result $r2, Result $r3, callable $transform): Result
     {
-        $r1 = $fn1();
-        $r2 = $fn2();
-        $r3 = $fn3();
-
         $errors = self::collectErrors($r1, $r2, $r3);
 
         if ($errors !== []) {
@@ -189,20 +218,15 @@ abstract class Result
      * @template T4
      * @template E1
      * @template U
-     * @param callable(): Result<T1, E1> $fn1
-     * @param callable(): Result<T2, E1> $fn2
-     * @param callable(): Result<T3, E1> $fn3
-     * @param callable(): Result<T4, E1> $fn4
+     * @param Result<T1, E1> $r1
+     * @param Result<T2, E1> $r2
+     * @param Result<T3, E1> $r3
+     * @param Result<T4, E1> $r4
      * @param callable(T1, T2, T3, T4): U $transform
      * @return Result<U, non-empty-list<E1>>
      */
-    public static function accumulate4(callable $fn1, callable $fn2, callable $fn3, callable $fn4, callable $transform): Result
+    public static function accumulate4(Result $r1, Result $r2, Result $r3, Result $r4, callable $transform): Result
     {
-        $r1 = $fn1();
-        $r2 = $fn2();
-        $r3 = $fn3();
-        $r4 = $fn4();
-
         $errors = self::collectErrors($r1, $r2, $r3, $r4);
 
         if ($errors !== []) {
@@ -223,22 +247,16 @@ abstract class Result
      * @template T5
      * @template E1
      * @template U
-     * @param callable(): Result<T1, E1> $fn1
-     * @param callable(): Result<T2, E1> $fn2
-     * @param callable(): Result<T3, E1> $fn3
-     * @param callable(): Result<T4, E1> $fn4
-     * @param callable(): Result<T5, E1> $fn5
+     * @param Result<T1, E1> $r1
+     * @param Result<T2, E1> $r2
+     * @param Result<T3, E1> $r3
+     * @param Result<T4, E1> $r4
+     * @param Result<T5, E1> $r5
      * @param callable(T1, T2, T3, T4, T5): U $transform
      * @return Result<U, non-empty-list<E1>>
      */
-    public static function accumulate5(callable $fn1, callable $fn2, callable $fn3, callable $fn4, callable $fn5, callable $transform): Result
+    public static function accumulate5(Result $r1, Result $r2, Result $r3, Result $r4, Result $r5, callable $transform): Result
     {
-        $r1 = $fn1();
-        $r2 = $fn2();
-        $r3 = $fn3();
-        $r4 = $fn4();
-        $r5 = $fn5();
-
         $errors = self::collectErrors($r1, $r2, $r3, $r4, $r5);
 
         if ($errors !== []) {
@@ -260,24 +278,17 @@ abstract class Result
      * @template T6
      * @template E1
      * @template U
-     * @param callable(): Result<T1, E1> $fn1
-     * @param callable(): Result<T2, E1> $fn2
-     * @param callable(): Result<T3, E1> $fn3
-     * @param callable(): Result<T4, E1> $fn4
-     * @param callable(): Result<T5, E1> $fn5
-     * @param callable(): Result<T6, E1> $fn6
+     * @param Result<T1, E1> $r1
+     * @param Result<T2, E1> $r2
+     * @param Result<T3, E1> $r3
+     * @param Result<T4, E1> $r4
+     * @param Result<T5, E1> $r5
+     * @param Result<T6, E1> $r6
      * @param callable(T1, T2, T3, T4, T5, T6): U $transform
      * @return Result<U, non-empty-list<E1>>
      */
-    public static function accumulate6(callable $fn1, callable $fn2, callable $fn3, callable $fn4, callable $fn5, callable $fn6, callable $transform): Result
+    public static function accumulate6(Result $r1, Result $r2, Result $r3, Result $r4, Result $r5, Result $r6, callable $transform): Result
     {
-        $r1 = $fn1();
-        $r2 = $fn2();
-        $r3 = $fn3();
-        $r4 = $fn4();
-        $r5 = $fn5();
-        $r6 = $fn6();
-
         $errors = self::collectErrors($r1, $r2, $r3, $r4, $r5, $r6);
 
         if ($errors !== []) {
@@ -300,26 +311,18 @@ abstract class Result
      * @template T7
      * @template E1
      * @template U
-     * @param callable(): Result<T1, E1> $fn1
-     * @param callable(): Result<T2, E1> $fn2
-     * @param callable(): Result<T3, E1> $fn3
-     * @param callable(): Result<T4, E1> $fn4
-     * @param callable(): Result<T5, E1> $fn5
-     * @param callable(): Result<T6, E1> $fn6
-     * @param callable(): Result<T7, E1> $fn7
+     * @param Result<T1, E1> $r1
+     * @param Result<T2, E1> $r2
+     * @param Result<T3, E1> $r3
+     * @param Result<T4, E1> $r4
+     * @param Result<T5, E1> $r5
+     * @param Result<T6, E1> $r6
+     * @param Result<T7, E1> $r7
      * @param callable(T1, T2, T3, T4, T5, T6, T7): U $transform
      * @return Result<U, non-empty-list<E1>>
      */
-    public static function accumulate7(callable $fn1, callable $fn2, callable $fn3, callable $fn4, callable $fn5, callable $fn6, callable $fn7, callable $transform): Result
+    public static function accumulate7(Result $r1, Result $r2, Result $r3, Result $r4, Result $r5, Result $r6, Result $r7, callable $transform): Result
     {
-        $r1 = $fn1();
-        $r2 = $fn2();
-        $r3 = $fn3();
-        $r4 = $fn4();
-        $r5 = $fn5();
-        $r6 = $fn6();
-        $r7 = $fn7();
-
         $errors = self::collectErrors($r1, $r2, $r3, $r4, $r5, $r6, $r7);
 
         if ($errors !== []) {
@@ -343,28 +346,19 @@ abstract class Result
      * @template T8
      * @template E1
      * @template U
-     * @param callable(): Result<T1, E1> $fn1
-     * @param callable(): Result<T2, E1> $fn2
-     * @param callable(): Result<T3, E1> $fn3
-     * @param callable(): Result<T4, E1> $fn4
-     * @param callable(): Result<T5, E1> $fn5
-     * @param callable(): Result<T6, E1> $fn6
-     * @param callable(): Result<T7, E1> $fn7
-     * @param callable(): Result<T8, E1> $fn8
+     * @param Result<T1, E1> $r1
+     * @param Result<T2, E1> $r2
+     * @param Result<T3, E1> $r3
+     * @param Result<T4, E1> $r4
+     * @param Result<T5, E1> $r5
+     * @param Result<T6, E1> $r6
+     * @param Result<T7, E1> $r7
+     * @param Result<T8, E1> $r8
      * @param callable(T1, T2, T3, T4, T5, T6, T7, T8): U $transform
      * @return Result<U, non-empty-list<E1>>
      */
-    public static function accumulate8(callable $fn1, callable $fn2, callable $fn3, callable $fn4, callable $fn5, callable $fn6, callable $fn7, callable $fn8, callable $transform): Result
+    public static function accumulate8(Result $r1, Result $r2, Result $r3, Result $r4, Result $r5, Result $r6, Result $r7, Result $r8, callable $transform): Result
     {
-        $r1 = $fn1();
-        $r2 = $fn2();
-        $r3 = $fn3();
-        $r4 = $fn4();
-        $r5 = $fn5();
-        $r6 = $fn6();
-        $r7 = $fn7();
-        $r8 = $fn8();
-
         $errors = self::collectErrors($r1, $r2, $r3, $r4, $r5, $r6, $r7, $r8);
 
         if ($errors !== []) {
@@ -389,30 +383,20 @@ abstract class Result
      * @template T9
      * @template E1
      * @template U
-     * @param callable(): Result<T1, E1> $fn1
-     * @param callable(): Result<T2, E1> $fn2
-     * @param callable(): Result<T3, E1> $fn3
-     * @param callable(): Result<T4, E1> $fn4
-     * @param callable(): Result<T5, E1> $fn5
-     * @param callable(): Result<T6, E1> $fn6
-     * @param callable(): Result<T7, E1> $fn7
-     * @param callable(): Result<T8, E1> $fn8
-     * @param callable(): Result<T9, E1> $fn9
+     * @param Result<T1, E1> $r1
+     * @param Result<T2, E1> $r2
+     * @param Result<T3, E1> $r3
+     * @param Result<T4, E1> $r4
+     * @param Result<T5, E1> $r5
+     * @param Result<T6, E1> $r6
+     * @param Result<T7, E1> $r7
+     * @param Result<T8, E1> $r8
+     * @param Result<T9, E1> $r9
      * @param callable(T1, T2, T3, T4, T5, T6, T7, T8, T9): U $transform
      * @return Result<U, non-empty-list<E1>>
      */
-    public static function accumulate9(callable $fn1, callable $fn2, callable $fn3, callable $fn4, callable $fn5, callable $fn6, callable $fn7, callable $fn8, callable $fn9, callable $transform): Result
+    public static function accumulate9(Result $r1, Result $r2, Result $r3, Result $r4, Result $r5, Result $r6, Result $r7, Result $r8, Result $r9, callable $transform): Result
     {
-        $r1 = $fn1();
-        $r2 = $fn2();
-        $r3 = $fn3();
-        $r4 = $fn4();
-        $r5 = $fn5();
-        $r6 = $fn6();
-        $r7 = $fn7();
-        $r8 = $fn8();
-        $r9 = $fn9();
-
         $errors = self::collectErrors($r1, $r2, $r3, $r4, $r5, $r6, $r7, $r8, $r9);
 
         if ($errors !== []) {

--- a/src/Result.php
+++ b/src/Result.php
@@ -108,6 +108,11 @@ abstract class Result
 
             if ($result instanceof Success) {
                 $generator->send($result->get());
+            } else {
+                throw new ResultException(
+                    'binding() generator must yield Result instances, got: '
+                    . get_debug_type($result)
+                );
             }
         }
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -623,7 +623,9 @@ abstract class Result
      * If the success value is not a Result, returns this Result unchanged.
      * For Failure, returns the Failure unchanged.
      *
-     * @return Result<mixed, mixed> The flattened Result
+     * @return (T is \Jsoizo\Result\Result<*, *>
+     *     ? \Jsoizo\Result\Result<template-type<T, \Jsoizo\Result\Result, 'T'>, E|template-type<T, \Jsoizo\Result\Result, 'E'>>
+     *     : Result<T, E>)
      */
     abstract public function flatten(): Result;
 }

--- a/src/Success.php
+++ b/src/Success.php
@@ -164,10 +164,9 @@ final class Success extends Result
      *
      * For Success, returns this instance unchanged since there is no error to recover from.
      *
-     * @param callable(E): T $fn The recovery function (not called)
-     * @return Success<T, E> This Success instance
-     *
-     * @phpstan-ignore generics.variance (T is covariant but used in contravariant position in callable parameter for practical API design)
+     * @template T1 The type of the recovery value (unused)
+     * @param callable(E): T1 $fn The recovery function (not called)
+     * @return Success<T, never> This Success instance
      */
     public function recover(callable $fn): Success
     {
@@ -179,11 +178,10 @@ final class Success extends Result
      *
      * For Success, returns this instance unchanged since there is no error to recover from.
      *
+     * @template T1 The success type of the resulting Result (unused)
      * @template E1 The error type of the resulting Result (unused)
-     * @param callable(E): Result<T, E1> $fn The recovery function (not called)
-     * @return Success<T, E> This Success instance
-     *
-     * @phpstan-ignore generics.variance (T is covariant but used in contravariant position in callable parameter for practical API design)
+     * @param callable(E): Result<T1, E1> $fn The recovery function (not called)
+     * @return Success<T, never> This Success instance
      */
     public function recoverWith(callable $fn): Success
     {

--- a/src/Success.php
+++ b/src/Success.php
@@ -141,7 +141,7 @@ final class Success extends Result
      */
     public function getError(): never
     {
-        throw new ResultException('Result is a success');
+        throw new ResultException('Result is a success: ' . get_debug_type($this->value));
     }
 
     /**
@@ -233,9 +233,12 @@ final class Success extends Result
      *
      * For Success, if the value is a Result, returns it. Otherwise returns this Success.
      *
-     * @return (T is \Jsoizo\Result\Result<*, *>
-     *     ? \Jsoizo\Result\Result<template-type<T, \Jsoizo\Result\Result, 'T'>, E|template-type<T, \Jsoizo\Result\Result, 'E'>>
-     *     : Result<T, E>)
+     * @return (T is never
+     *     ? Result<never, E>
+     *     : (T is \Jsoizo\Result\Result<*, *>
+     *         ? \Jsoizo\Result\Result<template-type<T, \Jsoizo\Result\Result, 'T'>, E|template-type<T, \Jsoizo\Result\Result, 'E'>>
+     *         : Result<T, E>))
+     * @phpstan-ignore conditionalType.alwaysFalse (never is a subtype of every type, so the outer branch must stay reachable for narrowed T)
      */
     public function flatten(): Result
     {

--- a/src/Success.php
+++ b/src/Success.php
@@ -233,7 +233,9 @@ final class Success extends Result
      *
      * For Success, if the value is a Result, returns it. Otherwise returns this Success.
      *
-     * @return Result<mixed, mixed> The inner Result or this Success
+     * @return (T is \Jsoizo\Result\Result<*, *>
+     *     ? \Jsoizo\Result\Result<template-type<T, \Jsoizo\Result\Result, 'T'>, E|template-type<T, \Jsoizo\Result\Result, 'E'>>
+     *     : Result<T, E>)
      */
     public function flatten(): Result
     {

--- a/tests/FailureTest.php
+++ b/tests/FailureTest.php
@@ -52,13 +52,15 @@ describe('Failure', function (): void {
         it('throws ResultException for non-Throwable error', function (): void {
             $result = Result::failure('error string');
 
-            expect(fn () => $result->get())->toThrow(ResultException::class);
+            expect(fn () => $result->get())
+                ->toThrow(ResultException::class, 'Result is a failure: string');
         });
 
         it('throws ResultException for array error', function (): void {
             $result = Result::failure(['code' => 404, 'message' => 'Not Found']);
 
-            expect(fn () => $result->get())->toThrow(ResultException::class);
+            expect(fn () => $result->get())
+                ->toThrow(ResultException::class, 'Result is a failure: array');
         });
     });
 

--- a/tests/PHPStan/data/result-type-narrowing.php
+++ b/tests/PHPStan/data/result-type-narrowing.php
@@ -139,3 +139,14 @@ function testFlattenKeepsNonNestedTypes(Result $result): void
 
     assertType('Jsoizo\Result\Result<int, string>', $flattened);
 }
+
+function testSequenceCollectsValuesOrErrors(): void
+{
+    $sequenced = Result::sequence([
+        Result::success(1),
+        Result::success(2),
+        Result::failure('error'),
+    ]);
+
+    assertType('Jsoizo\Result\Result<list<int>, non-empty-list<string>>', $sequenced);
+}

--- a/tests/PHPStan/data/result-type-narrowing.php
+++ b/tests/PHPStan/data/result-type-narrowing.php
@@ -109,3 +109,33 @@ function testRecoverWithCanChangeSuccessAndErrorTypes(Result $result): void
 
     assertType('Jsoizo\Result\Result<int, RuntimeException>', $recovered);
 }
+
+/**
+ * @param Result<Result<int, string>, string> $result
+ */
+function testFlattenPreservesNestedTypes(Result $result): void
+{
+    $flattened = $result->flatten();
+
+    assertType('Jsoizo\Result\Result<int, string>', $flattened);
+}
+
+/**
+ * @param Result<Result<int, string>, int> $result
+ */
+function testFlattenUnionsOuterAndInnerErrorTypes(Result $result): void
+{
+    $flattened = $result->flatten();
+
+    assertType('Jsoizo\Result\Result<int, int|string>', $flattened);
+}
+
+/**
+ * @param Result<int, string> $result
+ */
+function testFlattenKeepsNonNestedTypes(Result $result): void
+{
+    $flattened = $result->flatten();
+
+    assertType('Jsoizo\Result\Result<int, string>', $flattened);
+}

--- a/tests/PHPStan/data/result-type-narrowing.php
+++ b/tests/PHPStan/data/result-type-narrowing.php
@@ -16,6 +16,28 @@ final class DbError
 {
 }
 
+function stringifyInt(int $value): string
+{
+    return (string) $value;
+}
+
+/**
+ * @param int $value
+ * @param ValidationError $error
+ */
+function testFactoriesInferNeverSides(int $value, ValidationError $error): void
+{
+    assertType('Jsoizo\Result\Success<int, never>', Result::success($value));
+    assertType('Jsoizo\Result\Failure<never, Jsoizo\Result\Tests\PHPStan\Data\ValidationError>', Result::failure($error));
+}
+
+function testCatchInfersThrowableError(): void
+{
+    $caught = Result::catch(fn (): int => 1);
+
+    assertType('Jsoizo\Result\Result<int, Throwable>', $caught);
+}
+
 /**
  * @param Result<int, string> $result
  */
@@ -81,6 +103,26 @@ function testComplexTypes(Result $result): void
 }
 
 /**
+ * @param Result<int, string> $result
+ */
+function testMapChangesSuccessType(Result $result): void
+{
+    $mapped = $result->map(fn (int $value): string => stringifyInt($value));
+
+    assertType('Jsoizo\Result\Result<string, string>', $mapped);
+}
+
+/**
+ * @param Result<int, string> $result
+ */
+function testMapErrorChangesErrorType(Result $result): void
+{
+    $mapped = $result->mapError(fn (string $error) => new \RuntimeException($error));
+
+    assertType('Jsoizo\Result\Result<int, RuntimeException>', $mapped);
+}
+
+/**
  * @param Result<string, ValidationError> $result
  */
 function testFlatMapPreservesOriginalError(Result $result): void
@@ -88,6 +130,17 @@ function testFlatMapPreservesOriginalError(Result $result): void
     $mapped = $result->flatMap(fn (string $value) => Result::failure(new DbError()));
 
     assertType('Jsoizo\Result\Result<never, Jsoizo\Result\Tests\PHPStan\Data\DbError|Jsoizo\Result\Tests\PHPStan\Data\ValidationError>', $mapped);
+}
+
+/**
+ * @param Result<int, string> $result
+ * @param callable(int): Result<string, never> $fn
+ */
+function testFlatMapCanChangeSuccessType(Result $result, callable $fn): void
+{
+    $mapped = $result->flatMap($fn);
+
+    assertType('Jsoizo\Result\Result<string, string>', $mapped);
 }
 
 /**
@@ -108,6 +161,16 @@ function testRecoverWithCanChangeSuccessAndErrorTypes(Result $result): void
     $recovered = $result->recoverWith(fn (string $error) => Result::failure(new \RuntimeException($error)));
 
     assertType('Jsoizo\Result\Result<int, RuntimeException>', $recovered);
+}
+
+/**
+ * @param Result<int, string> $result
+ */
+function testRecoverWithCanAddSuccessType(Result $result): void
+{
+    $recovered = $result->recoverWith(fn (string $error) => Result::success($error));
+
+    assertType('Jsoizo\Result\Result<int|string, never>', $recovered);
 }
 
 /**
@@ -140,6 +203,45 @@ function testFlattenKeepsNonNestedTypes(Result $result): void
     assertType('Jsoizo\Result\Result<int, string>', $flattened);
 }
 
+/**
+ * @param Result<int, string> $result
+ */
+function testFallbackMethodsUnionDefaults(Result $result): void
+{
+    assertType('int|false', $result->getOrElse(false));
+    assertType('RuntimeException|string', $result->getErrorOrElse(new \RuntimeException()));
+}
+
+/**
+ * @param Result<int, string> $result
+ */
+function testFoldUnionsCallbackReturnTypes(Result $result): void
+{
+    $folded = $result->fold(
+        fn (string $error) => false,
+        fn (int $value) => $value,
+    );
+
+    assertType('int|false', $folded);
+}
+
+/**
+ * @param Result<int, string> $result
+ */
+function testTapMethodsPreserveResultType(Result $result): void
+{
+    assertType('Jsoizo\Result\Result<int, string>', $result->tap(fn (int $value): null => null));
+    assertType('Jsoizo\Result\Result<int, string>', $result->tapError(fn (string $error): null => null));
+}
+
+/**
+ * @param Result<int, string> $result
+ */
+function testGetOrNullUnionsNull(Result $result): void
+{
+    assertType('int|null', $result->getOrNull());
+}
+
 function testSequenceCollectsValuesOrErrors(): void
 {
     $sequenced = Result::sequence([
@@ -149,4 +251,19 @@ function testSequenceCollectsValuesOrErrors(): void
     ]);
 
     assertType('Jsoizo\Result\Result<list<int>, non-empty-list<string>>', $sequenced);
+}
+
+/**
+ * @param Result<string, ValidationError> $name
+ * @param Result<int, ValidationError> $age
+ */
+function testAccumulate2InfersTransformAndErrors(Result $name, Result $age): void
+{
+    $accumulated = Result::accumulate2(
+        $name,
+        $age,
+        fn (string $name, int $age): array => ['name' => $name, 'age' => $age],
+    );
+
+    assertType('Jsoizo\Result\Result<array{name: string, age: int}, non-empty-list<Jsoizo\Result\Tests\PHPStan\Data\ValidationError>>', $accumulated);
 }

--- a/tests/PHPStan/data/result-type-narrowing.php
+++ b/tests/PHPStan/data/result-type-narrowing.php
@@ -277,26 +277,26 @@ function testGetOrNullUnionsNull(Result $result): void
     assertType('int|null', $result->getOrNull());
 }
 
-function testSequenceCollectsValuesOrErrors(): void
+function testAccumulateCollectsValuesOrErrors(): void
 {
-    $sequenced = Result::sequence([
+    $accumulated = Result::accumulate([
         Result::success(1),
         Result::success(2),
         Result::failure('error'),
     ]);
 
-    assertType('Jsoizo\Result\Result<list<int>, non-empty-list<string>>', $sequenced);
+    assertType('Jsoizo\Result\Result<list<int>, non-empty-list<string>>', $accumulated);
 }
 
 /**
  * @param Result<int, ValidationError> $validationResult
  * @param Result<int, DbError> $dbResult
  */
-function testSequenceUnionsErrorTypes(Result $validationResult, Result $dbResult): void
+function testAccumulateUnionsErrorTypes(Result $validationResult, Result $dbResult): void
 {
-    $sequenced = Result::sequence([$validationResult, $dbResult]);
+    $accumulated = Result::accumulate([$validationResult, $dbResult]);
 
-    assertType('Jsoizo\Result\Result<list<int>, non-empty-list<Jsoizo\Result\Tests\PHPStan\Data\DbError|Jsoizo\Result\Tests\PHPStan\Data\ValidationError>>', $sequenced);
+    assertType('Jsoizo\Result\Result<list<int>, non-empty-list<Jsoizo\Result\Tests\PHPStan\Data\DbError|Jsoizo\Result\Tests\PHPStan\Data\ValidationError>>', $accumulated);
 }
 
 /**
@@ -312,6 +312,17 @@ function testAccumulate2InfersTransformAndErrors(Result $name, Result $age): voi
     );
 
     assertType('Jsoizo\Result\Result<array{name: string, age: int}, non-empty-list<Jsoizo\Result\Tests\PHPStan\Data\ValidationError>>', $accumulated);
+}
+
+/**
+ * @param Result<string, ValidationError> $r1
+ * @param Result<int, DbError> $r2
+ */
+function testAccumulate2UnionsErrorTypes(Result $r1, Result $r2): void
+{
+    $accumulated = Result::accumulate2($r1, $r2, fn (string $a, int $b): string => $a);
+
+    assertType('Jsoizo\Result\Result<string, non-empty-list<Jsoizo\Result\Tests\PHPStan\Data\DbError|Jsoizo\Result\Tests\PHPStan\Data\ValidationError>>', $accumulated);
 }
 
 /**
@@ -385,4 +396,29 @@ function testConcreteClassMethodsInferSpecificTypes(Success $success, Failure $f
     assertType('Jsoizo\Result\Result<string, Jsoizo\Result\Tests\PHPStan\Data\ValidationError|string>', $failure->flatMap($fn));
     assertType('Jsoizo\Result\Success<bool, never>', $failure->recover(fn (string $error): bool => false));
     assertType('Jsoizo\Result\Result<never, Jsoizo\Result\Tests\PHPStan\Data\DbError>', $failure->recoverWith(fn (string $error) => Result::failure(new DbError())));
+}
+
+/**
+ * @param Success<Result<int, string>, DbError> $nestedSuccess
+ * @param Failure<Result<int, string>, DbError> $nestedFailure
+ * @param Success<int, DbError> $plainSuccess
+ * @param Failure<int, DbError> $plainFailure
+ */
+function testConcreteFlattenInfersSpecificTypes(
+    Success $nestedSuccess,
+    Failure $nestedFailure,
+    Success $plainSuccess,
+    Failure $plainFailure,
+): void {
+    assertType('Jsoizo\Result\Result<int, Jsoizo\Result\Tests\PHPStan\Data\DbError|string>', $nestedSuccess->flatten());
+    assertType('Jsoizo\Result\Result<int, Jsoizo\Result\Tests\PHPStan\Data\DbError|string>', $nestedFailure->flatten());
+    assertType('Jsoizo\Result\Result<int, Jsoizo\Result\Tests\PHPStan\Data\DbError>', $plainSuccess->flatten());
+    assertType('Jsoizo\Result\Result<int, Jsoizo\Result\Tests\PHPStan\Data\DbError>', $plainFailure->flatten());
+}
+
+function testConcreteFlattenOnNeverReceiverStaysClean(): void
+{
+    $neverFailure = Result::failure(new DbError());
+
+    assertType('Jsoizo\Result\Result<never, Jsoizo\Result\Tests\PHPStan\Data\DbError>', $neverFailure->flatten());
 }

--- a/tests/PHPStan/data/result-type-narrowing.php
+++ b/tests/PHPStan/data/result-type-narrowing.php
@@ -8,6 +8,14 @@ use Jsoizo\Result\Result;
 
 use function PHPStan\Testing\assertType;
 
+final class ValidationError
+{
+}
+
+final class DbError
+{
+}
+
 /**
  * @param Result<int, string> $result
  */
@@ -70,4 +78,14 @@ function testComplexTypes(Result $result): void
     } else {
         assertType('Jsoizo\Result\Failure<array{name: string}, Exception>', $result);
     }
+}
+
+/**
+ * @param Result<string, ValidationError> $result
+ */
+function testFlatMapPreservesOriginalError(Result $result): void
+{
+    $mapped = $result->flatMap(fn (string $value) => Result::failure(new DbError()));
+
+    assertType('Jsoizo\Result\Result<never, Jsoizo\Result\Tests\PHPStan\Data\DbError|Jsoizo\Result\Tests\PHPStan\Data\ValidationError>', $mapped);
 }

--- a/tests/PHPStan/data/result-type-narrowing.php
+++ b/tests/PHPStan/data/result-type-narrowing.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Jsoizo\Result\Tests\PHPStan\Data;
 
+use Jsoizo\Result\Failure;
 use Jsoizo\Result\Result;
+use Jsoizo\Result\Success;
 
 use function PHPStan\Testing\assertType;
 
@@ -88,6 +90,20 @@ function testEarlyReturn(Result $result): int
     assertType('Jsoizo\Result\Success<int, string>', $result);
 
     return $result->get();
+}
+
+/**
+ * @param Result<int, string> $result
+ */
+function testNarrowedAccessorsInferContainedTypes(Result $result): void
+{
+    if ($result->isSuccess()) {
+        assertType('int', $result->get());
+    }
+
+    if ($result->isFailure()) {
+        assertType('string', $result->getError());
+    }
 }
 
 /**
@@ -204,6 +220,25 @@ function testFlattenKeepsNonNestedTypes(Result $result): void
 }
 
 /**
+ * @param Result<string, ValidationError> $name
+ * @param Result<int, ValidationError> $age
+ */
+function testBindingInfersReturnAndErrorTypes(Result $name, Result $age): void
+{
+    $bound = Result::binding(function () use ($name, $age): \Generator {
+        /** @var string $unwrappedName */
+        $unwrappedName = yield $name;
+
+        /** @var int $unwrappedAge */
+        $unwrappedAge = yield $age;
+
+        return ['name' => $unwrappedName, 'age' => $unwrappedAge];
+    });
+
+    assertType('Jsoizo\Result\Result<array{name: string, age: int}, Jsoizo\Result\Tests\PHPStan\Data\ValidationError>', $bound);
+}
+
+/**
  * @param Result<int, string> $result
  */
 function testFallbackMethodsUnionDefaults(Result $result): void
@@ -254,6 +289,17 @@ function testSequenceCollectsValuesOrErrors(): void
 }
 
 /**
+ * @param Result<int, ValidationError> $validationResult
+ * @param Result<int, DbError> $dbResult
+ */
+function testSequenceUnionsErrorTypes(Result $validationResult, Result $dbResult): void
+{
+    $sequenced = Result::sequence([$validationResult, $dbResult]);
+
+    assertType('Jsoizo\Result\Result<list<int>, non-empty-list<Jsoizo\Result\Tests\PHPStan\Data\DbError|Jsoizo\Result\Tests\PHPStan\Data\ValidationError>>', $sequenced);
+}
+
+/**
  * @param Result<string, ValidationError> $name
  * @param Result<int, ValidationError> $age
  */
@@ -266,4 +312,77 @@ function testAccumulate2InfersTransformAndErrors(Result $name, Result $age): voi
     );
 
     assertType('Jsoizo\Result\Result<array{name: string, age: int}, non-empty-list<Jsoizo\Result\Tests\PHPStan\Data\ValidationError>>', $accumulated);
+}
+
+/**
+ * @param Result<string, ValidationError> $r1
+ * @param Result<int, ValidationError> $r2
+ * @param Result<bool, ValidationError> $r3
+ * @param Result<float, ValidationError> $r4
+ * @param Result<ValidationError, ValidationError> $r5
+ * @param Result<DbError, ValidationError> $r6
+ * @param Result<\DateTimeImmutable, ValidationError> $r7
+ * @param Result<list<string>, ValidationError> $r8
+ * @param Result<array{id: int}, ValidationError> $r9
+ */
+function testAccumulate9InfersTransformArgumentsAndReturnType(
+    Result $r1,
+    Result $r2,
+    Result $r3,
+    Result $r4,
+    Result $r5,
+    Result $r6,
+    Result $r7,
+    Result $r8,
+    Result $r9,
+): void {
+    $accumulated = Result::accumulate9(
+        $r1,
+        $r2,
+        $r3,
+        $r4,
+        $r5,
+        $r6,
+        $r7,
+        $r8,
+        $r9,
+        fn (
+            string $text,
+            int $count,
+            bool $enabled,
+            float $ratio,
+            ValidationError $validationError,
+            DbError $dbError,
+            \DateTimeImmutable $createdAt,
+            array $tags,
+            array $payload,
+        ): array => [
+            'text' => $text,
+            'count' => $count,
+            'enabled' => $enabled,
+            'ratio' => $ratio,
+        ],
+    );
+
+    assertType('Jsoizo\Result\Result<array{text: string, count: int, enabled: bool, ratio: float}, non-empty-list<Jsoizo\Result\Tests\PHPStan\Data\ValidationError>>', $accumulated);
+}
+
+/**
+ * @param Success<int, string> $success
+ * @param Failure<int, string> $failure
+ * @param callable(int): Result<string, ValidationError> $fn
+ */
+function testConcreteClassMethodsInferSpecificTypes(Success $success, Failure $failure, callable $fn): void
+{
+    assertType('Jsoizo\Result\Success<string, string>', $success->map(fn (int $value): string => stringifyInt($value)));
+    assertType('Jsoizo\Result\Success<int, RuntimeException>', $success->mapError(fn (string $error) => new \RuntimeException($error)));
+    assertType('Jsoizo\Result\Result<string, Jsoizo\Result\Tests\PHPStan\Data\ValidationError>', $success->flatMap($fn));
+    assertType('Jsoizo\Result\Success<int, never>', $success->recover(fn (string $error): bool => false));
+    assertType('Jsoizo\Result\Success<int, never>', $success->recoverWith(fn (string $error) => Result::failure(new DbError())));
+
+    assertType('Jsoizo\Result\Failure<string, string>', $failure->map(fn (int $value): string => stringifyInt($value)));
+    assertType('Jsoizo\Result\Failure<int, RuntimeException>', $failure->mapError(fn (string $error) => new \RuntimeException($error)));
+    assertType('Jsoizo\Result\Result<string, Jsoizo\Result\Tests\PHPStan\Data\ValidationError|string>', $failure->flatMap($fn));
+    assertType('Jsoizo\Result\Success<bool, never>', $failure->recover(fn (string $error): bool => false));
+    assertType('Jsoizo\Result\Result<never, Jsoizo\Result\Tests\PHPStan\Data\DbError>', $failure->recoverWith(fn (string $error) => Result::failure(new DbError())));
 }

--- a/tests/PHPStan/data/result-type-narrowing.php
+++ b/tests/PHPStan/data/result-type-narrowing.php
@@ -89,3 +89,23 @@ function testFlatMapPreservesOriginalError(Result $result): void
 
     assertType('Jsoizo\Result\Result<never, Jsoizo\Result\Tests\PHPStan\Data\DbError|Jsoizo\Result\Tests\PHPStan\Data\ValidationError>', $mapped);
 }
+
+/**
+ * @param Result<int, string> $result
+ */
+function testRecoverCanChangeSuccessType(Result $result): void
+{
+    $recovered = $result->recover(fn (string $error) => false);
+
+    assertType('Jsoizo\Result\Result<bool|int, never>', $recovered);
+}
+
+/**
+ * @param Result<int, string> $result
+ */
+function testRecoverWithCanChangeSuccessAndErrorTypes(Result $result): void
+{
+    $recovered = $result->recoverWith(fn (string $error) => Result::failure(new \RuntimeException($error)));
+
+    assertType('Jsoizo\Result\Result<int, RuntimeException>', $recovered);
+}

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -232,11 +232,55 @@ describe('Result::binding', function (): void {
     });
 });
 
+describe('Result::sequence', function (): void {
+    it('returns Success with empty list for empty input', function (): void {
+        /** @var list<Result<int, string>> $results */
+        $results = [];
+        $result = Result::sequence($results);
+
+        expect($result)->toBeInstanceOf(Success::class);
+        expect($result->getOrElse(['fallback']))->toBe([]);
+    });
+
+    it('returns Success with values when all Results are Success', function (): void {
+        $result = Result::sequence([
+            Result::success(1),
+            Result::success(2),
+            Result::success(3),
+        ]);
+
+        expect($result)->toBeInstanceOf(Success::class);
+        expect($result->getOrElse([]))->toBe([1, 2, 3]);
+    });
+
+    it('returns Failure with single error when one Result fails', function (): void {
+        $result = Result::sequence([
+            Result::success(1),
+            Result::failure('error'),
+            Result::success(3),
+        ]);
+
+        expect($result)->toBeInstanceOf(Failure::class);
+        expect($result->getErrorOrElse([]))->toBe(['error']);
+    });
+
+    it('collects all errors in input order', function (): void {
+        $result = Result::sequence([
+            Result::failure('first'),
+            Result::success(2),
+            Result::failure('second'),
+        ]);
+
+        expect($result)->toBeInstanceOf(Failure::class);
+        expect($result->getErrorOrElse([]))->toBe(['first', 'second']);
+    });
+});
+
 describe('Result::accumulate2', function (): void {
     it('returns Success with transformed value when all are Success', function (): void {
         $result = Result::accumulate2(
-            fn () => Result::success(1),
-            fn () => Result::success(2),
+            Result::success(1),
+            Result::success(2),
             fn (int $a, int $b) => $a + $b
         );
 
@@ -246,8 +290,8 @@ describe('Result::accumulate2', function (): void {
 
     it('returns Failure with single error when one fails', function (): void {
         $result = Result::accumulate2(
-            fn () => Result::success(1),
-            fn () => Result::failure('error2'),
+            Result::success(1),
+            Result::failure('error2'),
             fn (int $a, int $b) => $a + $b
         );
 
@@ -257,8 +301,8 @@ describe('Result::accumulate2', function (): void {
 
     it('collects all errors when all fail', function (): void {
         $result = Result::accumulate2(
-            fn () => Result::failure('error1'),
-            fn () => Result::failure('error2'),
+            Result::failure('error1'),
+            Result::failure('error2'),
             fn (int $a, int $b) => $a + $b
         );
 
@@ -270,8 +314,8 @@ describe('Result::accumulate2', function (): void {
         $called = false;
         $validate = fn (int $x): Result => $x > 0 ? Result::success($x) : Result::failure('must be positive');
         Result::accumulate2(
-            fn () => Result::success(1),
-            fn () => $validate(-1),
+            Result::success(1),
+            $validate(-1),
             function (int $a, int $b) use (&$called): int {
                 $called = true;
 
@@ -284,8 +328,8 @@ describe('Result::accumulate2', function (): void {
 
     it('works with different value types', function (): void {
         $result = Result::accumulate2(
-            fn () => Result::success('hello'),
-            fn () => Result::success(42),
+            Result::success('hello'),
+            Result::success(42),
             fn (string $s, int $n) => "{$s}: {$n}"
         );
 
@@ -295,8 +339,8 @@ describe('Result::accumulate2', function (): void {
 
     it('preserves error order matching argument order', function (): void {
         $result = Result::accumulate2(
-            fn () => Result::failure('first'),
-            fn () => Result::failure('second'),
+            Result::failure('first'),
+            Result::failure('second'),
             fn (int $a, int $b) => $a + $b
         );
 
@@ -307,9 +351,9 @@ describe('Result::accumulate2', function (): void {
 describe('Result::accumulate3', function (): void {
     it('returns Success with transformed value when all are Success', function (): void {
         $result = Result::accumulate3(
-            fn () => Result::success(1),
-            fn () => Result::success(2),
-            fn () => Result::success(3),
+            Result::success(1),
+            Result::success(2),
+            Result::success(3),
             fn (int $a, int $b, int $c) => $a + $b + $c
         );
 
@@ -319,9 +363,9 @@ describe('Result::accumulate3', function (): void {
 
     it('collects errors from failed Results', function (): void {
         $result = Result::accumulate3(
-            fn () => Result::success(1),
-            fn () => Result::failure('e2'),
-            fn () => Result::failure('e3'),
+            Result::success(1),
+            Result::failure('e2'),
+            Result::failure('e3'),
             fn (int $a, int $b, int $c) => $a + $b + $c
         );
 
@@ -331,9 +375,9 @@ describe('Result::accumulate3', function (): void {
 
     it('collects all errors when all fail', function (): void {
         $result = Result::accumulate3(
-            fn () => Result::failure('e1'),
-            fn () => Result::failure('e2'),
-            fn () => Result::failure('e3'),
+            Result::failure('e1'),
+            Result::failure('e2'),
+            Result::failure('e3'),
             fn (int $a, int $b, int $c) => $a + $b + $c
         );
 
@@ -345,10 +389,10 @@ describe('Result::accumulate3', function (): void {
 describe('Result::accumulate4', function (): void {
     it('returns Success with transformed value when all are Success', function (): void {
         $result = Result::accumulate4(
-            fn () => Result::success(1),
-            fn () => Result::success(2),
-            fn () => Result::success(3),
-            fn () => Result::success(4),
+            Result::success(1),
+            Result::success(2),
+            Result::success(3),
+            Result::success(4),
             fn (int $a, int $b, int $c, int $d) => $a + $b + $c + $d
         );
 
@@ -358,10 +402,10 @@ describe('Result::accumulate4', function (): void {
 
     it('collects errors from failed Results', function (): void {
         $result = Result::accumulate4(
-            fn () => Result::success(1),
-            fn () => Result::failure('e2'),
-            fn () => Result::success(3),
-            fn () => Result::failure('e4'),
+            Result::success(1),
+            Result::failure('e2'),
+            Result::success(3),
+            Result::failure('e4'),
             fn (int $a, int $b, int $c, int $d) => $a + $b + $c + $d
         );
 
@@ -371,10 +415,10 @@ describe('Result::accumulate4', function (): void {
 
     it('collects all errors when all fail', function (): void {
         $result = Result::accumulate4(
-            fn () => Result::failure('e1'),
-            fn () => Result::failure('e2'),
-            fn () => Result::failure('e3'),
-            fn () => Result::failure('e4'),
+            Result::failure('e1'),
+            Result::failure('e2'),
+            Result::failure('e3'),
+            Result::failure('e4'),
             fn (int $a, int $b, int $c, int $d) => $a + $b + $c + $d
         );
 
@@ -386,11 +430,11 @@ describe('Result::accumulate4', function (): void {
 describe('Result::accumulate5', function (): void {
     it('returns Success with transformed value when all are Success', function (): void {
         $result = Result::accumulate5(
-            fn () => Result::success(1),
-            fn () => Result::success(2),
-            fn () => Result::success(3),
-            fn () => Result::success(4),
-            fn () => Result::success(5),
+            Result::success(1),
+            Result::success(2),
+            Result::success(3),
+            Result::success(4),
+            Result::success(5),
             fn (int $a, int $b, int $c, int $d, int $e) => $a + $b + $c + $d + $e
         );
 
@@ -400,11 +444,11 @@ describe('Result::accumulate5', function (): void {
 
     it('collects errors from failed Results', function (): void {
         $result = Result::accumulate5(
-            fn () => Result::failure('e1'),
-            fn () => Result::success(2),
-            fn () => Result::failure('e3'),
-            fn () => Result::success(4),
-            fn () => Result::failure('e5'),
+            Result::failure('e1'),
+            Result::success(2),
+            Result::failure('e3'),
+            Result::success(4),
+            Result::failure('e5'),
             fn (int $a, int $b, int $c, int $d, int $e) => $a + $b + $c + $d + $e
         );
 
@@ -414,11 +458,11 @@ describe('Result::accumulate5', function (): void {
 
     it('collects all errors when all fail', function (): void {
         $result = Result::accumulate5(
-            fn () => Result::failure('e1'),
-            fn () => Result::failure('e2'),
-            fn () => Result::failure('e3'),
-            fn () => Result::failure('e4'),
-            fn () => Result::failure('e5'),
+            Result::failure('e1'),
+            Result::failure('e2'),
+            Result::failure('e3'),
+            Result::failure('e4'),
+            Result::failure('e5'),
             fn (int $a, int $b, int $c, int $d, int $e) => $a + $b + $c + $d + $e
         );
 
@@ -430,12 +474,12 @@ describe('Result::accumulate5', function (): void {
 describe('Result::accumulate6', function (): void {
     it('returns Success with transformed value when all are Success', function (): void {
         $result = Result::accumulate6(
-            fn () => Result::success(1),
-            fn () => Result::success(2),
-            fn () => Result::success(3),
-            fn () => Result::success(4),
-            fn () => Result::success(5),
-            fn () => Result::success(6),
+            Result::success(1),
+            Result::success(2),
+            Result::success(3),
+            Result::success(4),
+            Result::success(5),
+            Result::success(6),
             fn (int $a, int $b, int $c, int $d, int $e, int $f) => $a + $b + $c + $d + $e + $f
         );
 
@@ -445,12 +489,12 @@ describe('Result::accumulate6', function (): void {
 
     it('collects errors from failed Results', function (): void {
         $result = Result::accumulate6(
-            fn () => Result::failure('e1'),
-            fn () => Result::success(2),
-            fn () => Result::success(3),
-            fn () => Result::failure('e4'),
-            fn () => Result::success(5),
-            fn () => Result::failure('e6'),
+            Result::failure('e1'),
+            Result::success(2),
+            Result::success(3),
+            Result::failure('e4'),
+            Result::success(5),
+            Result::failure('e6'),
             fn (int $a, int $b, int $c, int $d, int $e, int $f) => $a + $b + $c + $d + $e + $f
         );
 
@@ -460,12 +504,12 @@ describe('Result::accumulate6', function (): void {
 
     it('collects all errors when all fail', function (): void {
         $result = Result::accumulate6(
-            fn () => Result::failure('e1'),
-            fn () => Result::failure('e2'),
-            fn () => Result::failure('e3'),
-            fn () => Result::failure('e4'),
-            fn () => Result::failure('e5'),
-            fn () => Result::failure('e6'),
+            Result::failure('e1'),
+            Result::failure('e2'),
+            Result::failure('e3'),
+            Result::failure('e4'),
+            Result::failure('e5'),
+            Result::failure('e6'),
             fn (int $a, int $b, int $c, int $d, int $e, int $f) => $a + $b + $c + $d + $e + $f
         );
 
@@ -477,13 +521,13 @@ describe('Result::accumulate6', function (): void {
 describe('Result::accumulate7', function (): void {
     it('returns Success with transformed value when all are Success', function (): void {
         $result = Result::accumulate7(
-            fn () => Result::success(1),
-            fn () => Result::success(2),
-            fn () => Result::success(3),
-            fn () => Result::success(4),
-            fn () => Result::success(5),
-            fn () => Result::success(6),
-            fn () => Result::success(7),
+            Result::success(1),
+            Result::success(2),
+            Result::success(3),
+            Result::success(4),
+            Result::success(5),
+            Result::success(6),
+            Result::success(7),
             fn (int $a, int $b, int $c, int $d, int $e, int $f, int $g) => $a + $b + $c + $d + $e + $f + $g
         );
 
@@ -493,13 +537,13 @@ describe('Result::accumulate7', function (): void {
 
     it('collects errors from failed Results', function (): void {
         $result = Result::accumulate7(
-            fn () => Result::success(1),
-            fn () => Result::failure('e2'),
-            fn () => Result::success(3),
-            fn () => Result::success(4),
-            fn () => Result::failure('e5'),
-            fn () => Result::success(6),
-            fn () => Result::failure('e7'),
+            Result::success(1),
+            Result::failure('e2'),
+            Result::success(3),
+            Result::success(4),
+            Result::failure('e5'),
+            Result::success(6),
+            Result::failure('e7'),
             fn (int $a, int $b, int $c, int $d, int $e, int $f, int $g) => $a + $b + $c + $d + $e + $f + $g
         );
 
@@ -509,13 +553,13 @@ describe('Result::accumulate7', function (): void {
 
     it('collects all errors when all fail', function (): void {
         $result = Result::accumulate7(
-            fn () => Result::failure('e1'),
-            fn () => Result::failure('e2'),
-            fn () => Result::failure('e3'),
-            fn () => Result::failure('e4'),
-            fn () => Result::failure('e5'),
-            fn () => Result::failure('e6'),
-            fn () => Result::failure('e7'),
+            Result::failure('e1'),
+            Result::failure('e2'),
+            Result::failure('e3'),
+            Result::failure('e4'),
+            Result::failure('e5'),
+            Result::failure('e6'),
+            Result::failure('e7'),
             fn (int $a, int $b, int $c, int $d, int $e, int $f, int $g) => $a + $b + $c + $d + $e + $f + $g
         );
 
@@ -527,14 +571,14 @@ describe('Result::accumulate7', function (): void {
 describe('Result::accumulate8', function (): void {
     it('returns Success with transformed value when all are Success', function (): void {
         $result = Result::accumulate8(
-            fn () => Result::success(1),
-            fn () => Result::success(2),
-            fn () => Result::success(3),
-            fn () => Result::success(4),
-            fn () => Result::success(5),
-            fn () => Result::success(6),
-            fn () => Result::success(7),
-            fn () => Result::success(8),
+            Result::success(1),
+            Result::success(2),
+            Result::success(3),
+            Result::success(4),
+            Result::success(5),
+            Result::success(6),
+            Result::success(7),
+            Result::success(8),
             fn (int $a, int $b, int $c, int $d, int $e, int $f, int $g, int $h) => $a + $b + $c + $d + $e + $f + $g + $h
         );
 
@@ -544,14 +588,14 @@ describe('Result::accumulate8', function (): void {
 
     it('collects errors from failed Results', function (): void {
         $result = Result::accumulate8(
-            fn () => Result::failure('e1'),
-            fn () => Result::success(2),
-            fn () => Result::failure('e3'),
-            fn () => Result::success(4),
-            fn () => Result::success(5),
-            fn () => Result::failure('e6'),
-            fn () => Result::success(7),
-            fn () => Result::failure('e8'),
+            Result::failure('e1'),
+            Result::success(2),
+            Result::failure('e3'),
+            Result::success(4),
+            Result::success(5),
+            Result::failure('e6'),
+            Result::success(7),
+            Result::failure('e8'),
             fn (int $a, int $b, int $c, int $d, int $e, int $f, int $g, int $h) => $a + $b + $c + $d + $e + $f + $g + $h
         );
 
@@ -561,14 +605,14 @@ describe('Result::accumulate8', function (): void {
 
     it('collects all errors when all fail', function (): void {
         $result = Result::accumulate8(
-            fn () => Result::failure('e1'),
-            fn () => Result::failure('e2'),
-            fn () => Result::failure('e3'),
-            fn () => Result::failure('e4'),
-            fn () => Result::failure('e5'),
-            fn () => Result::failure('e6'),
-            fn () => Result::failure('e7'),
-            fn () => Result::failure('e8'),
+            Result::failure('e1'),
+            Result::failure('e2'),
+            Result::failure('e3'),
+            Result::failure('e4'),
+            Result::failure('e5'),
+            Result::failure('e6'),
+            Result::failure('e7'),
+            Result::failure('e8'),
             fn (int $a, int $b, int $c, int $d, int $e, int $f, int $g, int $h) => $a + $b + $c + $d + $e + $f + $g + $h
         );
 
@@ -580,15 +624,15 @@ describe('Result::accumulate8', function (): void {
 describe('Result::accumulate9', function (): void {
     it('returns Success with transformed value when all are Success', function (): void {
         $result = Result::accumulate9(
-            fn () => Result::success(1),
-            fn () => Result::success(2),
-            fn () => Result::success(3),
-            fn () => Result::success(4),
-            fn () => Result::success(5),
-            fn () => Result::success(6),
-            fn () => Result::success(7),
-            fn () => Result::success(8),
-            fn () => Result::success(9),
+            Result::success(1),
+            Result::success(2),
+            Result::success(3),
+            Result::success(4),
+            Result::success(5),
+            Result::success(6),
+            Result::success(7),
+            Result::success(8),
+            Result::success(9),
             fn (int $a, int $b, int $c, int $d, int $e, int $f, int $g, int $h, int $i) => $a + $b + $c + $d + $e + $f + $g + $h + $i
         );
 
@@ -598,15 +642,15 @@ describe('Result::accumulate9', function (): void {
 
     it('collects errors from failed Results', function (): void {
         $result = Result::accumulate9(
-            fn () => Result::success(1),
-            fn () => Result::failure('e2'),
-            fn () => Result::success(3),
-            fn () => Result::failure('e4'),
-            fn () => Result::success(5),
-            fn () => Result::success(6),
-            fn () => Result::failure('e7'),
-            fn () => Result::success(8),
-            fn () => Result::failure('e9'),
+            Result::success(1),
+            Result::failure('e2'),
+            Result::success(3),
+            Result::failure('e4'),
+            Result::success(5),
+            Result::success(6),
+            Result::failure('e7'),
+            Result::success(8),
+            Result::failure('e9'),
             fn (int $a, int $b, int $c, int $d, int $e, int $f, int $g, int $h, int $i) => $a + $b + $c + $d + $e + $f + $g + $h + $i
         );
 
@@ -616,15 +660,15 @@ describe('Result::accumulate9', function (): void {
 
     it('collects all errors when all fail', function (): void {
         $result = Result::accumulate9(
-            fn () => Result::failure('e1'),
-            fn () => Result::failure('e2'),
-            fn () => Result::failure('e3'),
-            fn () => Result::failure('e4'),
-            fn () => Result::failure('e5'),
-            fn () => Result::failure('e6'),
-            fn () => Result::failure('e7'),
-            fn () => Result::failure('e8'),
-            fn () => Result::failure('e9'),
+            Result::failure('e1'),
+            Result::failure('e2'),
+            Result::failure('e3'),
+            Result::failure('e4'),
+            Result::failure('e5'),
+            Result::failure('e6'),
+            Result::failure('e7'),
+            Result::failure('e8'),
+            Result::failure('e9'),
             fn (int $a, int $b, int $c, int $d, int $e, int $f, int $g, int $h, int $i) => $a + $b + $c + $d + $e + $f + $g + $h + $i
         );
 
@@ -634,15 +678,15 @@ describe('Result::accumulate9', function (): void {
 
     it('passes all 9 arguments correctly to transform', function (): void {
         $result = Result::accumulate9(
-            fn () => Result::success('a'),
-            fn () => Result::success('b'),
-            fn () => Result::success('c'),
-            fn () => Result::success('d'),
-            fn () => Result::success('e'),
-            fn () => Result::success('f'),
-            fn () => Result::success('g'),
-            fn () => Result::success('h'),
-            fn () => Result::success('i'),
+            Result::success('a'),
+            Result::success('b'),
+            Result::success('c'),
+            Result::success('d'),
+            Result::success('e'),
+            Result::success('f'),
+            Result::success('g'),
+            Result::success('h'),
+            Result::success('i'),
             fn (string $a, string $b, string $c, string $d, string $e, string $f, string $g, string $h, string $i) => $a . $b . $c . $d . $e . $f . $g . $h . $i
         );
 

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -230,20 +230,37 @@ describe('Result::binding', function (): void {
             'binding() generator must yield Result instances, got: int'
         );
     });
+
+    it('throws when callable does not return a Generator', function (): void {
+        // @phpstan-ignore-next-line argument.type (Testing invalid callable return)
+        expect(fn () => Result::binding(fn () => 42))->toThrow(
+            ResultException::class,
+            'binding() callable must return a Generator, got: int'
+        );
+    });
+
+    it('propagates exceptions thrown inside the generator', function (): void {
+        expect(fn () => Result::binding(function () {
+            /** @var int $x */
+            $x = yield Result::success(1);
+
+            throw new RuntimeException('boom');
+        }))->toThrow(RuntimeException::class, 'boom');
+    });
 });
 
-describe('Result::sequence', function (): void {
+describe('Result::accumulate', function (): void {
     it('returns Success with empty list for empty input', function (): void {
         /** @var list<Result<int, string>> $results */
         $results = [];
-        $result = Result::sequence($results);
+        $result = Result::accumulate($results);
 
         expect($result)->toBeInstanceOf(Success::class);
         expect($result->getOrElse(['fallback']))->toBe([]);
     });
 
     it('returns Success with values when all Results are Success', function (): void {
-        $result = Result::sequence([
+        $result = Result::accumulate([
             Result::success(1),
             Result::success(2),
             Result::success(3),
@@ -254,7 +271,7 @@ describe('Result::sequence', function (): void {
     });
 
     it('returns Failure with single error when one Result fails', function (): void {
-        $result = Result::sequence([
+        $result = Result::accumulate([
             Result::success(1),
             Result::failure('error'),
             Result::success(3),
@@ -265,7 +282,7 @@ describe('Result::sequence', function (): void {
     });
 
     it('collects all errors in input order', function (): void {
-        $result = Result::sequence([
+        $result = Result::accumulate([
             Result::failure('first'),
             Result::success(2),
             Result::failure('second'),
@@ -273,6 +290,14 @@ describe('Result::sequence', function (): void {
 
         expect($result)->toBeInstanceOf(Failure::class);
         expect($result->getErrorOrElse([]))->toBe(['first', 'second']);
+    });
+
+    it('throws when an element is not a Result instance', function (): void {
+        // @phpstan-ignore-next-line argument.type (Testing invalid list element)
+        expect(fn () => Result::accumulate([Result::success(1), 'oops']))->toThrow(
+            ResultException::class,
+            'accumulate() expects Result instances, got: string'
+        );
     });
 });
 

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Jsoizo\Result\Failure;
 use Jsoizo\Result\Result;
+use Jsoizo\Result\ResultException;
 use Jsoizo\Result\Success;
 
 describe('Result::success', function (): void {
@@ -200,6 +201,34 @@ describe('Result::binding', function (): void {
 
         expect($result)->toBeInstanceOf(Success::class);
         expect($result->getOrElse(0))->toBe(42);
+    });
+
+    it('throws when generator yields null', function (): void {
+        // @phpstan-ignore-next-line argument.type (Testing invalid generator yield)
+        expect(fn () => Result::binding(function () {
+            /** @var int $x */
+            $x = yield Result::success(1);
+            yield;
+
+            return $x;
+        }))->toThrow(
+            ResultException::class,
+            'binding() generator must yield Result instances, got: null'
+        );
+    });
+
+    it('throws when generator yields non-Result value', function (): void {
+        // @phpstan-ignore-next-line argument.type (Testing invalid generator yield)
+        expect(fn () => Result::binding(function () {
+            /** @var int $x */
+            $x = yield Result::success(1);
+            yield 42;
+
+            return $x;
+        }))->toThrow(
+            ResultException::class,
+            'binding() generator must yield Result instances, got: int'
+        );
     });
 });
 

--- a/tests/SuccessTest.php
+++ b/tests/SuccessTest.php
@@ -172,7 +172,14 @@ describe('Success', function (): void {
             $result = Result::success('value');
 
             expect(fn () => $result->getError())
-                ->toThrow(ResultException::class, 'Result is a success');
+                ->toThrow(ResultException::class, 'Result is a success: string');
+        });
+
+        it('throws ResultException for array value', function (): void {
+            $result = Result::success(['code' => 200, 'message' => 'OK']);
+
+            expect(fn () => $result->getError())
+                ->toThrow(ResultException::class, 'Result is a success: array');
         });
     });
 


### PR DESCRIPTION
## Summary

Improves the type-level contracts of the Result API so PHPStan (level max) infers precise types through common combinator chains, hardens runtime misuse diagnostics, and adds an error-accumulating list combinator.

## Type contract changes (released APIs)

| Method | Before | After |
|---|---|---|
| `flatMap()` | `@return Result<T1, E1>` | `@return Result<T1, E\|E1>` — preserves the original error type |
| `recover()` | `callable(E): T` / `@return Result<T, E>` | `callable(E): T1` / `@return Result<T\|T1, never>` — recovery may change the success type; the result can no longer fail |
| `recoverWith()` | `callable(E): Result<T, E1>` / `@return Result<T, E1>` | `callable(E): Result<T1, E1>` / `@return Result<T\|T1, E1>` |
| `flatten()` | `@return Result<mixed, mixed>` | Conditional type: nested `Result<Result<T1, E1>, E2>` flattens to `Result<T1, E1\|E2>`; non-nested stays `Result<T, E>`; guarded for `T = never` receivers (`Result::failure()` results) |

These are PHPDoc-level changes only — no runtime behavior changes. Consumers running PHPStan may see wider (more accurate) inferred types; `mapError()` remains the tool to normalize error unions at boundaries.

## New API

- `Result::accumulate(array $results)` — converts `list<Result<T, E>>` into `Result<list<T>, non-empty-list<E>>`, collecting **all** errors (no short-circuit). Named `accumulate` (not `sequence`) deliberately: in FP tradition `sequence` short-circuits on the first error, while this method belongs to the same error-accumulating family as `accumulate2()`–`accumulate9()`.
- `Result::accumulate2()`–`accumulate9()` (unreleased, added in this cycle) now accept `Result` instances directly instead of callables — the callables provided no laziness (all were invoked unconditionally) and only added ceremony.

## Fixes & diagnostics

- `Result::binding()` no longer hangs forever when a generator yields a non-Result value — it throws `ResultException` with the offending type.
- `Result::binding()` now throws a descriptive `ResultException` when the callable does not return a `Generator` (previously an opaque `Error: Call to undefined method ...::valid()`).
- `Result::accumulate()` throws a descriptive `ResultException` for non-Result elements (same failure mode as the binding fix).
- `Failure::get()` / `Success::getError()` exception messages now include the value's type (`get_debug_type`), type name only — error values may carry sensitive data, so they are never embedded.

## Tests

- PHPStan type-inference tests for: `flatMap` error unions, `recover` → `never`, `flatten` conditional types (abstract + concrete `Success`/`Failure` receivers, `never` receivers), heterogeneous error-type unions for `accumulate2()` and `accumulate()`.
- Runtime pins for: all new guard exceptions (message included), `binding()` exception propagation (exceptions inside the generator intentionally propagate — use `Result::catch` to capture), `accumulate()` edge cases (empty list, ordering, mixed).
- 178 tests, 267 assertions, 100% coverage.

## CI

- New `PHP 8.1 Syntax Check` job running `php -l` on an actual PHP 8.1 interpreter. The existing compatibility check (phpcompatibility 9.3, no PHP 8.x sniffs) cannot detect 8.2+-only syntax; this closes the gap cheaply. Verified locally that a syntax error fails the job (`php -l` exits 255 → xargs aborts non-zero).

## Notes for reviewers

- Some earlier commits labeled `fix:` change public PHPDoc type contracts (`c264aff`, `1a4c58a`, `b7fbc92`); they are type-level only. The `accumulate2-9` signature change in `b01cf44` is safe — that API never shipped.
- `CHANGELOG.md` documents all changes with before/after signatures; `CLAUDE.md`'s PHP version claim was corrected to match `composer.json` (`^8.1` runtime, 8.2+ dev tooling).
