### PR TITLE
feat: add getErrorOrNull() for nullable error extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `getErrorOrNull()` method for extracting error as nullable (symmetric with `getOrNull()`)
 - `Result::accumulate2()` through `Result::accumulate9()` for combining multiple Result instances with error accumulation
 - `Result::accumulate()` for converting a list of Results into one Result while collecting all errors; throws `ResultException` if any element is not a Result instance
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ $result = validateInput($data)
 // Get value as nullable
 $value = $result->getOrNull(); // T|null
 
+// Get error as nullable
+if (($error = $result->getErrorOrNull()) !== null) {
+    logger()->error("Failed: $error");
+}
+
 // Flatten nested Results
 $nested = Result::success(Result::success(42));
 $flat = $nested->flatten(); // Success(42)
@@ -154,6 +159,7 @@ Use `accumulate($results)` for a homogeneous list of same-typed Results; use `ac
 | `tap($fn)` | Execute side effect on success value, return same Result |
 | `tapError($fn)` | Execute side effect on error value, return same Result |
 | `getOrNull()` | Get success value or null |
+| `getErrorOrNull()` | Get error value or null |
 | `flatten()` | Flatten nested `Result<Result<T, E1>, E2>` into `Result<T, E1\|E2>` |
 
 ### Error Types in flatMap

--- a/src/Failure.php
+++ b/src/Failure.php
@@ -238,6 +238,18 @@ final class Failure extends Result
     /**
      * {@inheritDoc}
      *
+     * For Failure, returns the contained error.
+     *
+     * @return E The error value
+     */
+    public function getErrorOrNull(): mixed
+    {
+        return $this->error;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * For Failure, returns this Failure unchanged. The success value can never
      * be a Result, so the type stays consistent with the abstract declaration.
      *

--- a/src/Result.php
+++ b/src/Result.php
@@ -607,6 +607,16 @@ abstract class Result
     abstract public function getOrNull(): mixed;
 
     /**
+     * Returns the error value, or null if this is a Success.
+     *
+     * Provides a convenient way to extract the error with null as the default.
+     * For Failure, returns the contained error. For Success, returns null.
+     *
+     * @return E|null The error value or null
+     */
+    abstract public function getErrorOrNull(): mixed;
+
+    /**
      * Flattens a nested Result into a single Result.
      *
      * If the success value is itself a Result, unwraps it and returns the inner Result.

--- a/src/Success.php
+++ b/src/Success.php
@@ -231,6 +231,18 @@ final class Success extends Result
     /**
      * {@inheritDoc}
      *
+     * For Success, returns null since there is no error value.
+     *
+     * @return null Always null
+     */
+    public function getErrorOrNull(): mixed
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * For Success, if the value is a Result, returns it. Otherwise returns this Success.
      *
      * @return (T is never

--- a/tests/FailureTest.php
+++ b/tests/FailureTest.php
@@ -317,6 +317,27 @@ describe('Failure', function (): void {
         });
     });
 
+    describe('getErrorOrNull', function (): void {
+        it('returns error', function (): void {
+            $result = Result::failure('error message');
+
+            expect($result->getErrorOrNull())->toBe('error message');
+        });
+
+        it('returns exception error', function (): void {
+            $exception = new RuntimeException('oops');
+            $result = Result::failure($exception);
+
+            expect($result->getErrorOrNull())->toBe($exception);
+        });
+
+        it('returns null when error is null', function (): void {
+            $result = Result::failure(null);
+
+            expect($result->getErrorOrNull())->toBeNull();
+        });
+    });
+
     describe('flatten', function (): void {
         it('returns same Failure unchanged', function (): void {
             $result = Result::failure('error');

--- a/tests/PHPStan/data/result-type-narrowing.php
+++ b/tests/PHPStan/data/result-type-narrowing.php
@@ -277,6 +277,20 @@ function testGetOrNullUnionsNull(Result $result): void
     assertType('int|null', $result->getOrNull());
 }
 
+/**
+ * @param Result<int, string> $result
+ */
+function testGetErrorOrNullUnionsNull(Result $result): void
+{
+    assertType('string|null', $result->getErrorOrNull());
+
+    if ($result->isFailure()) {
+        assertType('string', $result->getErrorOrNull());
+    } else {
+        assertType('null', $result->getErrorOrNull());
+    }
+}
+
 function testAccumulateCollectsValuesOrErrors(): void
 {
     $accumulated = Result::accumulate([

--- a/tests/SuccessTest.php
+++ b/tests/SuccessTest.php
@@ -286,6 +286,20 @@ describe('Success', function (): void {
         });
     });
 
+    describe('getErrorOrNull', function (): void {
+        it('returns null', function (): void {
+            $result = Result::success(42);
+
+            expect($result->getErrorOrNull())->toBeNull();
+        });
+
+        it('returns null regardless of value type', function (): void {
+            $result = Result::success('hello');
+
+            expect($result->getErrorOrNull())->toBeNull();
+        });
+    });
+
     describe('flatten', function (): void {
         it('flattens nested Success', function (): void {
             $nested = Result::success(Result::success(42));


### PR DESCRIPTION
# Add `getErrorOrNull()`

## Why

The success side of `Result` has a complete extraction triad — `get()`, `getOrElse()`, `getOrNull()` — but the error side only has `getError()` and `getErrorOrElse()`. The nullable accessor is missing, so the very common pattern "if there is an error, do something with it" is awkward today:

```php
// Before: either non-obvious...
$error = $result->getErrorOrElse(null);

// ...or unsafe: throws ResultException when $result is a Success
$error = $result->getError();
```

```php
// After: obvious and safe
if (($error = $result->getErrorOrNull()) !== null) {
    logger()->error("Failed: $error");
}
```

API symmetry also aids discoverability: users who know `getOrNull()` naturally reach for `getErrorOrNull()` without reading the docs.

## What

- `Result::getErrorOrNull(): E|null` — Failure returns the error, Success returns `null`
- Mirrors the existing `getOrNull()` implementations exactly (`Success` override documents `@return null`, `Failure` documents `@return E`), so PHPStan narrows the return type after `isSuccess()`/`isFailure()`
- Pest tests (success/failure/null-error edge case), PHPStan `assertType` assertions, README table + example, CHANGELOG entry

| State | `getOrNull()` | `getErrorOrNull()` (new) |
|-------|---------------|--------------------------|
| `Success<T, E>` | `T` | `null` |
| `Failure<T, E>` | `null` | `E` |

## Usage

```php
$error = $result->getErrorOrNull(); // E|null

if ($result->isFailure()) {
    $result->getErrorOrNull(); // PHPStan infers E (string, etc.)
}
```

## Design notes

Ecosystem precedent — nearly every Result/Either implementation pairs the value accessor with an error-side twin:

- **Rust**: `Result::ok() -> Option<T>` / `Result::err() -> Option<E>`
- **kotlin-result**: `get(): V?` / `getError(): E?`
- **Arrow-kt** (`Either`): `getOrNull()` / `leftOrNull()`

Alternatives considered:

- **Keep using `getErrorOrElse(null)`** — works, but widens the type to `E|null` via the default parameter and is not discoverable; rejected in favor of an explicit named method
- **Rust-style `err(): Option<E>`** — PHP has no `Option` type and this library's vocabulary is null-based (`getOrNull()`); rejected for consistency
- **Making `getError()` nullable instead** — breaking change, and throwing on misuse is intentional there; rejected

Known property (shared with `getOrNull()`): if `E` itself can be `null`, a `null` return is ambiguous — use `isFailure()` to disambiguate in that case.
