### PR TITLE
feat: add Result::sequence() for fail-fast list combination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `getErrorOrNull()` method for extracting error as nullable (symmetric with `getOrNull()`)
+- `Result::sequence()` for converting a list of Results into one Result with fail-fast semantics, returning the first error unwrapped; throws `ResultException` if any element is not a Result instance
 - `Result::accumulate2()` through `Result::accumulate9()` for combining multiple Result instances with error accumulation
 - `Result::accumulate()` for converting a list of Results into one Result while collecting all errors; throws `ResultException` if any element is not a Result instance
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ $result = Result::accumulate([
 // All Success → Success([name, age, email])
 // Any Failure → Failure(['Name required', 'Invalid email']) (non-empty-list of errors)
 
+// Sequence a list of Results into one, stopping at the first error
+$result = Result::sequence([
+    loadConfig($path),
+    connectDb($dsn),
+    fetchUser($id),
+]);
+// All Success → Success([config, connection, user])
+// Any Failure → Failure('config not found') (first error, unwrapped)
+
 // Accumulate errors from multiple independent validations
 $result = Result::accumulate3(
     validateName($input['name']),
@@ -118,7 +127,7 @@ $result = Result::accumulate3(
 // Any Failure → Failure(['Name required', 'Invalid email']) (non-empty-list of errors)
 ```
 
-Use `accumulate($results)` for a homogeneous list of same-typed Results; use `accumulate2()`–`accumulate9()` to combine differently-typed Results into one value via a transform function.
+Use `accumulate($results)` for a homogeneous list of same-typed Results; use `accumulate2()`–`accumulate9()` to combine differently-typed Results into one value via a transform function. Use `sequence($results)` when you want fail-fast semantics instead: validation → `accumulate` (report all errors), sequential composition → `sequence` (stop at the first failure, error type stays as-is).
 
 ## API
 
@@ -131,6 +140,7 @@ Use `accumulate($results)` for a homogeneous list of same-typed Results; use `ac
 | `Result::catch(callable $fn)` | Wrap exception-throwing code |
 | `Result::binding(callable $fn)` | Monad comprehension using generators |
 | `Result::accumulate($results)` | Convert a list of Results into one Result, collecting all errors |
+| `Result::sequence($results)` | Convert a list of Results into one Result, stopping at the first error |
 | `Result::accumulate2($r1, ..., $transform)` | Combine 2 Results, collecting all errors |
 | `Result::accumulate3($r1, ..., $transform)` | Combine 3 Results, collecting all errors |
 | `Result::accumulate4($r1, ..., $transform)` | Combine 4 Results, collecting all errors |

--- a/src/Result.php
+++ b/src/Result.php
@@ -170,6 +170,41 @@ abstract class Result
     }
 
     /**
+     * Converts a list of Results into a Result containing a list of values, failing fast.
+     *
+     * Iterates in input order and short-circuits on the first Failure, returning
+     * its error unwrapped. If every Result is a Success, returns a Success with
+     * values in input order. An empty list yields a Success with an empty list.
+     *
+     * @template T1
+     * @template E1
+     * @param list<Result<T1, E1>> $results
+     * @return Result<list<T1>, E1>
+     * @throws ResultException If any element of $results is not a Result instance
+     */
+    public static function sequence(array $results): Result
+    {
+        $values = [];
+
+        foreach ($results as $result) {
+            // @phpstan-ignore instanceof.alwaysTrue (guards list elements that violate the PHPDoc param type at runtime)
+            if (!$result instanceof Result) {
+                throw new ResultException(
+                    'sequence() expects Result instances, got: ' . get_debug_type($result)
+                );
+            }
+
+            if ($result->isFailure()) {
+                return self::failure($result->getError());
+            }
+
+            $values[] = $result->get();
+        }
+
+        return self::success($values);
+    }
+
+    /**
      * Combines two Results, collecting all errors on failure.
      *
      * Evaluates all Results without short-circuiting. If all are Success,

--- a/tests/PHPStan/data/result-type-narrowing.php
+++ b/tests/PHPStan/data/result-type-narrowing.php
@@ -313,6 +313,28 @@ function testAccumulateUnionsErrorTypes(Result $validationResult, Result $dbResu
     assertType('Jsoizo\Result\Result<list<int>, non-empty-list<Jsoizo\Result\Tests\PHPStan\Data\DbError|Jsoizo\Result\Tests\PHPStan\Data\ValidationError>>', $accumulated);
 }
 
+function testSequenceKeepsErrorTypeUnwrapped(): void
+{
+    $sequenced = Result::sequence([
+        Result::success(1),
+        Result::success(2),
+        Result::failure('error'),
+    ]);
+
+    assertType('Jsoizo\Result\Result<list<int>, string>', $sequenced);
+}
+
+/**
+ * @param Result<int, ValidationError> $validationResult
+ * @param Result<int, DbError> $dbResult
+ */
+function testSequenceUnionsErrorTypes(Result $validationResult, Result $dbResult): void
+{
+    $sequenced = Result::sequence([$validationResult, $dbResult]);
+
+    assertType('Jsoizo\Result\Result<list<int>, Jsoizo\Result\Tests\PHPStan\Data\DbError|Jsoizo\Result\Tests\PHPStan\Data\ValidationError>', $sequenced);
+}
+
 /**
  * @param Result<string, ValidationError> $name
  * @param Result<int, ValidationError> $age

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -301,6 +301,66 @@ describe('Result::accumulate', function (): void {
     });
 });
 
+describe('Result::sequence', function (): void {
+    it('returns Success with empty list for empty input', function (): void {
+        /** @var list<Result<int, string>> $results */
+        $results = [];
+        $result = Result::sequence($results);
+
+        expect($result)->toBeInstanceOf(Success::class);
+        expect($result->getOrElse(['fallback']))->toBe([]);
+    });
+
+    it('returns Success with values in input order when all Results are Success', function (): void {
+        $result = Result::sequence([
+            Result::success(1),
+            Result::success(2),
+            Result::success(3),
+        ]);
+
+        expect($result)->toBeInstanceOf(Success::class);
+        expect($result->getOrElse([]))->toBe([1, 2, 3]);
+    });
+
+    it('returns Failure with the unwrapped error when one Result fails', function (): void {
+        $result = Result::sequence([
+            Result::success(1),
+            Result::failure('error'),
+            Result::success(3),
+        ]);
+
+        expect($result)->toBeInstanceOf(Failure::class);
+        expect($result->getErrorOrElse('fallback'))->toBe('error');
+    });
+
+    it('returns the first error when multiple Results fail', function (): void {
+        $result = Result::sequence([
+            Result::failure('first'),
+            Result::success(2),
+            Result::failure('second'),
+        ]);
+
+        expect($result)->toBeInstanceOf(Failure::class);
+        expect($result->getErrorOrElse('fallback'))->toBe('first');
+    });
+
+    it('short-circuits without inspecting elements after the first Failure', function (): void {
+        // @phpstan-ignore-next-line argument.type (Testing short-circuit before element validation)
+        $result = Result::sequence([Result::failure('boom'), 'not a result']);
+
+        expect($result)->toBeInstanceOf(Failure::class);
+        expect($result->getErrorOrElse('fallback'))->toBe('boom');
+    });
+
+    it('throws when an element is not a Result instance', function (): void {
+        // @phpstan-ignore-next-line argument.type (Testing invalid list element)
+        expect(fn () => Result::sequence([Result::success(1), 'oops']))->toThrow(
+            ResultException::class,
+            'sequence() expects Result instances, got: string'
+        );
+    });
+});
+
 describe('Result::accumulate2', function (): void {
     it('returns Success with transformed value when all are Success', function (): void {
         $result = Result::accumulate2(


### PR DESCRIPTION
# Add `Result::sequence()` — fail-fast list combination

## Why

`accumulate()` answers one question: "validate everything and report **all** errors" — its error channel is `non-empty-list<E>`. But an equally common need is the opposite: combine N results for **sequential/dependent steps**, stop at the first failure, and keep the error type `E` as-is.

Without `sequence()`, users hit real friction:

```php
// Before: abuse accumulate() and unwrap a list nobody wanted
$result = Result::accumulate($results)
    ->mapError(fn(array $errors) => $errors[0]); // Result<list<T>, E> — awkward

// ...or write the manual loop every time
$values = [];
foreach ($results as $r) {
    if ($r->isFailure()) { return $r; }
    $values[] = $r->get();
}

// After
$result = Result::sequence($results); // Result<list<T>, E>
```

The `mapError` workaround also has the wrong evaluation semantics: it pays for full error collection when short-circuiting was the intent.

Fail-fast is the **default** semantics for this operation across ecosystems:

| Ecosystem | API | Semantics |
|---|---|---|
| Rust | `collect::<Result<Vec<T>, E>>()` | fail-fast |
| Haskell | `sequence` (Traversable) | fail-fast |
| Scala (cats) | `.sequence` | fail-fast |
| kotlin-result | `combine` | fail-fast (vs `zipOrAccumulate` collecting) |

The name `sequence` follows the FP tradition; it sits next to `accumulate()` as its fail-fast counterpart.

## What

- New static method `Result::sequence(array $results): Result`
  - `@param list<Result<T1, E1>>` → `@return Result<list<T1>, E1>`
  - First `Failure` wins; error stays **unwrapped** (not a list)
  - All `Success` → `Success` with values in input order; empty list → `Success([])`
  - Non-`Result` element throws `ResultException` (same runtime guard as `accumulate()`)
- Pest tests: success order, first-failure-wins, short-circuit (elements after the first `Failure` are not inspected), empty list, invalid element
- PHPStan `assertType` coverage for generics inference (incl. error-type union)
- README: usage example + one-line guidance (validation → `accumulate`, sequential composition → `sequence`); CHANGELOG entry

## Usage

```php
$result = Result::sequence([
    loadConfig($path),
    connectDb($dsn),
    fetchUser($id),
]);
// All Success → Success([config, connection, user])
// Any Failure → Failure('config not found') — first error, unwrapped
```

## Design notes

- **Return `self::failure($result->getError())` instead of the encountered `Failure` directly**: the encountered value is `Failure<T1, E1>`, which does not typecheck as `Result<list<T1>, E1>`. Re-wrapping yields `Failure<never, E1>`, which is sound (`never` is a subtype of `list<T1>`) and needs no extra PHPStan ignore.
- **Alternative rejected — error as `non-empty-list<E1>`**: that is exactly `accumulate()`; duplicating it adds nothing. The whole point of `sequence()` is keeping `E` unwrapped.
- **Alternative rejected — no runtime guard**: PHPDoc types are erased at runtime; a silent `TypeError` deep inside the loop is worse than the explicit `ResultException` used by `accumulate()` and `binding()`. The guard keeps diagnostics consistent.
- **Short-circuit before validation**: elements after the first `Failure` are never inspected, matching the lazy semantics of fail-fast combinators elsewhere (covered by a test).
