### PR TITLE
feat: add optional exception class filter to Result::catch()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `getErrorOrNull()` method for extracting error as nullable (symmetric with `getOrNull()`)
 - `Result::sequence()` for converting a list of Results into one Result with fail-fast semantics, returning the first error unwrapped; throws `ResultException` if any element is not a Result instance
+- Optional `$exceptionClass` parameter for `Result::catch()` to capture only the given exception class (others are rethrown) and narrow the error type
 - `Result::accumulate2()` through `Result::accumulate9()` for combining multiple Result instances with error accumulation
 - `Result::accumulate()` for converting a list of Results into one Result while collecting all errors; throws `ResultException` if any element is not a Result instance
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ $value = $failure->getOrElse(0); // 0
 // Catch exceptions
 $result = Result::catch(fn() => riskyOperation());
 
+// Catch only an expected exception class; anything else is rethrown
+$result = Result::catch(
+    fn() => json_decode($json, flags: JSON_THROW_ON_ERROR),
+    JsonException::class
+);
+// Result<mixed, JsonException> - a TypeError would propagate instead of becoming a Failure
+
 // Handle both cases with fold
 $message = $result->fold(
     onFailure: fn($error) => "Error: {$error->getMessage()}",
@@ -137,7 +144,7 @@ Use `accumulate($results)` for a homogeneous list of same-typed Results; use `ac
 |--------|-------------|
 | `Result::success($value)` | Create a Success |
 | `Result::failure($error)` | Create a Failure |
-| `Result::catch(callable $fn)` | Wrap exception-throwing code |
+| `Result::catch(callable $fn, string $exceptionClass = Throwable::class)` | Wrap exception-throwing code, optionally capturing only a given exception class |
 | `Result::binding(callable $fn)` | Monad comprehension using generators |
 | `Result::accumulate($results)` | Convert a list of Results into one Result, collecting all errors |
 | `Result::sequence($results)` | Convert a list of Results into one Result, stopping at the first error |

--- a/src/Result.php
+++ b/src/Result.php
@@ -60,15 +60,25 @@ abstract class Result
      * returning a Success with the result if no exception is thrown,
      * or a Failure containing the caught Throwable otherwise.
      *
+     * Passing $exceptionClass captures only that class (and its subclasses)
+     * and narrows the error type accordingly; any other Throwable is rethrown.
+     *
      * @template TValue The return type of the callable
+     * @template TException of \Throwable = \Throwable The exception class to capture
      * @param callable(): TValue $fn The callable to execute
-     * @return Result<TValue, \Throwable> Success with the return value, or Failure with the exception
+     * @param class-string<TException> $exceptionClass The exception class to capture as a Failure
+     * @return Result<TValue, TException> Success with the return value, or Failure with the exception
+     * @throws \Throwable If the thrown exception is not an instance of $exceptionClass
      */
-    public static function catch(callable $fn): Result
+    public static function catch(callable $fn, string $exceptionClass = \Throwable::class): Result
     {
         try {
             return self::success($fn());
         } catch (\Throwable $e) {
+            if (!$e instanceof $exceptionClass) {
+                throw $e;
+            }
+
             return self::failure($e);
         }
     }

--- a/tests/PHPStan/data/result-type-narrowing.php
+++ b/tests/PHPStan/data/result-type-narrowing.php
@@ -40,6 +40,13 @@ function testCatchInfersThrowableError(): void
     assertType('Jsoizo\Result\Result<int, Throwable>', $caught);
 }
 
+function testCatchWithExceptionClassNarrowsError(string $json): void
+{
+    $caught = Result::catch(fn (): mixed => json_decode($json, flags: JSON_THROW_ON_ERROR), \JsonException::class);
+
+    assertType('Jsoizo\Result\Result<mixed, JsonException>', $caught);
+}
+
 /**
  * @param Result<int, string> $result
  */

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -57,6 +57,47 @@ describe('Result::catch', function (): void {
 
         expect($result)->toBeInstanceOf(Failure::class);
     });
+
+    it('returns Success on normal execution with exception class', function (): void {
+        $result = Result::catch(fn () => 42, RuntimeException::class);
+
+        expect($result)->toBeInstanceOf(Success::class);
+        expect($result->getOrElse(0))->toBe(42);
+    });
+
+    it('catches matching exception class and returns Failure', function (): void {
+        $exception = new RuntimeException('oops');
+        $result = Result::catch(fn () => throw $exception, RuntimeException::class);
+
+        expect($result)->toBeInstanceOf(Failure::class);
+        expect($result->getError())->toBe($exception);
+    });
+
+    it('catches subclass of the given exception class', function (): void {
+        $exception = new InvalidArgumentException('bad input');
+        $result = Result::catch(fn () => throw $exception, LogicException::class);
+
+        expect($result)->toBeInstanceOf(Failure::class);
+        expect($result->getError())->toBe($exception);
+    });
+
+    it('rethrows exception not matching the given class', function (): void {
+        Result::catch(fn () => throw new TypeError('bug'), RuntimeException::class);
+    })->throws(TypeError::class, 'bug');
+
+    it('rethrows the original exception instance', function (): void {
+        $exception = new LogicException('bug');
+
+        try {
+            Result::catch(fn () => throw $exception, RuntimeException::class);
+        } catch (LogicException $caught) {
+            expect($caught)->toBe($exception);
+
+            return;
+        }
+
+        $this->fail('Expected LogicException to be rethrown');
+    });
 });
 
 describe('Result::fold', function (): void {


### PR DESCRIPTION
# Add optional exception class filter to `Result::catch()`

## Why

`Result::catch()` currently converts **every** `Throwable` into a `Failure` — including `\Error` subclasses like `TypeError` or `ArgumentCountError` that signal programming bugs, not expected failures. A later `recover()` can then silently swallow a genuine bug. The error channel is also always the maximally wide `\Throwable`, so callers must narrow manually.

```php
// Before: a TypeError (a bug!) becomes a Failure and gets "recovered"
$config = Result::catch(fn() => json_decode($raw, flags: JSON_THROW_ON_ERROR))
    ->recover(fn(Throwable $e) => defaultConfig()); // bug silently masked

// Before: error type is always Throwable — manual narrowing everywhere
$result->mapError(function (Throwable $e) {
    if (!$e instanceof JsonException) {
        throw $e;
    }
    return $e->getMessage();
});
```

```php
// After: declare which exception is the EXPECTED failure
$config = Result::catch(
    fn() => json_decode($raw, flags: JSON_THROW_ON_ERROR),
    JsonException::class
); // Result<mixed, JsonException> — a TypeError propagates as usual
```

- Genuine bugs are rethrown unchanged instead of entering the error channel
- The Result error type is narrowed statically, so `mapError`/`fold` callbacks receive the concrete exception type

## What

- `Result::catch(callable $fn, string $exceptionClass = \Throwable::class)` — optional second parameter, fully backward compatible
- Caught `Throwable` not matching `$exceptionClass` is rethrown; matching ones become `failure($e)`
- PHPDoc uses a template default type (`@template TException of \Throwable = \Throwable`) with `class-string<TException>`, so existing call sites still infer `Result<T, Throwable>`

| Call | Inferred type |
|------|---------------|
| `Result::catch($fn)` | `Result<T, Throwable>` (unchanged) |
| `Result::catch($fn, JsonException::class)` | `Result<T, JsonException>` |

Runtime behavior is PHPStan-version independent; consumers need PHPStan >= 2.0 to benefit from the narrowed type inference (template default types).

Tests cover: default behavior unchanged (Exception and Error captured), matching class captured, subclass captured, non-matching exception rethrown as the original instance, plus PHPStan type-inference assertions for both arities. Coverage remains 100%.

## Usage

```php
$user = Result::catch(fn() => $repo->findOrFail($id), ModelNotFoundException::class)
    ->recover(fn(ModelNotFoundException $e) => User::guest());
// Result<User, ModelNotFoundException>; an infrastructure Error still throws
```

## Design notes

- **Ecosystem precedent**: Arrow-kt's `Either.catch` rethrows fatal exceptions and offers `catchOrThrow<reified T>` to catch only `T`; Rust separates recoverable `Result` from panics at the type level; kotlin-result's blanket `runCatching` is a known pain point (e.g. the `CancellationException`-swallowing discussions); Scala's `Try`/`NonFatal` likewise excludes fatal errors from capture.
- **Alternative — hardcode rethrowing `\Error`** (Arrow/Scala style fatal filter): rejected. In PHP some `\Error` subclasses (`DivisionByZeroError`, `ValueError`) *are* input-dependent expected failures, so a fixed cut is wrong for real code. An opt-in class filter lets the caller draw the line.
- **Alternative — new method (`catchOnly()`)**: rejected. The default parameter is fully BC and keeps one obvious entry point; PHPStan template default types make the two arities type-safe without API surface growth.
- **Alternative — accept a list of classes**: deferred. A single `class-string<T>` keeps the generic inference exact; union needs can use a common ancestor or a second `catch` call.
