### PR TITLE
feat: add Result::fromNullable() for converting nullable values into Results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `getErrorOrNull()` method for extracting error as nullable (symmetric with `getOrNull()`)
 - `Result::sequence()` for converting a list of Results into one Result with fail-fast semantics, returning the first error unwrapped; throws `ResultException` if any element is not a Result instance
 - Optional `$exceptionClass` parameter for `Result::catch()` to capture only the given exception class (others are rethrown) and narrow the error type
+- `Result::fromNullable()` for converting nullable values into Results with a lazily produced error
 - `Result::accumulate2()` through `Result::accumulate9()` for combining multiple Result instances with error accumulation
 - `Result::accumulate()` for converting a list of Results into one Result while collecting all errors; throws `ResultException` if any element is not a Result instance
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ $result = Result::catch(
 );
 // Result<mixed, JsonException> - a TypeError would propagate instead of becoming a Failure
 
+// Convert a nullable value into a Result
+$result = Result::fromNullable($userRepo->find($id), fn() => 'user not found');
+// null → Failure('user not found'), non-null → Success(User)
+// Only null counts as absence: falsy values like '', 0, false become Success.
+
 // Handle both cases with fold
 $message = $result->fold(
     onFailure: fn($error) => "Error: {$error->getMessage()}",
@@ -145,6 +150,7 @@ Use `accumulate($results)` for a homogeneous list of same-typed Results; use `ac
 | `Result::success($value)` | Create a Success |
 | `Result::failure($error)` | Create a Failure |
 | `Result::catch(callable $fn, string $exceptionClass = Throwable::class)` | Wrap exception-throwing code, optionally capturing only a given exception class |
+| `Result::fromNullable($value, callable $onNull)` | Convert a nullable value into a Result |
 | `Result::binding(callable $fn)` | Monad comprehension using generators |
 | `Result::accumulate($results)` | Convert a list of Results into one Result, collecting all errors |
 | `Result::sequence($results)` | Convert a list of Results into one Result, stopping at the first error |

--- a/src/Result.php
+++ b/src/Result.php
@@ -84,6 +84,29 @@ abstract class Result
     }
 
     /**
+     * Converts a nullable value into a Result.
+     *
+     * If the value is null, calls $onNull to produce the error and returns a
+     * Failure. Otherwise returns a Success with the value. Only null is treated
+     * as absence: falsy values such as '', 0, false and [] become Success.
+     * The error is produced lazily, so $onNull is never called on the non-null path.
+     *
+     * @template TValue The type of the non-null value
+     * @template TError The type of the error value
+     * @param TValue|null $value The nullable value to convert
+     * @param callable(): TError $onNull The function producing the error when the value is null
+     * @return Result<TValue, TError> Success with the value, or Failure with the produced error
+     */
+    public static function fromNullable(mixed $value, callable $onNull): Result
+    {
+        if ($value === null) {
+            return self::failure($onNull());
+        }
+
+        return self::success($value);
+    }
+
+    /**
      * Enables monad comprehension syntax using generators.
      *
      * This method allows chaining multiple Result-returning operations in an

--- a/tests/PHPStan/data/result-type-narrowing.php
+++ b/tests/PHPStan/data/result-type-narrowing.php
@@ -47,6 +47,27 @@ function testCatchWithExceptionClassNarrowsError(string $json): void
     assertType('Jsoizo\Result\Result<mixed, JsonException>', $caught);
 }
 
+function testFromNullableSubtractsNullFromValueType(?ValidationError $maybe): void
+{
+    $result = Result::fromNullable($maybe, fn (): string => 'missing');
+
+    assertType('Jsoizo\Result\Result<Jsoizo\Result\Tests\PHPStan\Data\ValidationError, string>', $result);
+}
+
+function testFromNullableInfersErrorTypeFromCallable(?int $maybe): void
+{
+    $result = Result::fromNullable($maybe, fn () => new DbError());
+
+    assertType('Jsoizo\Result\Result<int, Jsoizo\Result\Tests\PHPStan\Data\DbError>', $result);
+}
+
+function testFromNullableKeepsNonNullableValueType(int $value): void
+{
+    $result = Result::fromNullable($value, fn (): string => 'missing');
+
+    assertType('Jsoizo\Result\Result<int, string>', $result);
+}
+
 /**
  * @param Result<int, string> $result
  */

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -100,6 +100,57 @@ describe('Result::catch', function (): void {
     });
 });
 
+describe('Result::fromNullable', function (): void {
+    it('returns Success for non-null value', function (): void {
+        $result = Result::fromNullable(42, fn () => 'missing');
+
+        expect($result)->toBeInstanceOf(Success::class);
+        expect($result->getOrElse(0))->toBe(42);
+    });
+
+    it('does not invoke onNull for non-null value', function (): void {
+        $calls = 0;
+        Result::fromNullable('value', function () use (&$calls): string {
+            $calls++;
+
+            return 'missing';
+        });
+
+        expect($calls)->toBe(0);
+    });
+
+    it('returns Failure with produced error for null', function (): void {
+        $result = Result::fromNullable(null, fn () => 'missing');
+
+        expect($result)->toBeInstanceOf(Failure::class);
+        expect($result->getErrorOrElse(''))->toBe('missing');
+    });
+
+    it('invokes onNull exactly once for null', function (): void {
+        $calls = 0;
+        Result::fromNullable(null, function () use (&$calls): string {
+            $calls++;
+
+            return 'missing';
+        });
+
+        expect($calls)->toBe(1);
+    });
+
+    it('treats falsy non-null values as Success', function (mixed $value): void {
+        $result = Result::fromNullable($value, fn () => 'missing');
+
+        expect($result)->toBeInstanceOf(Success::class);
+        expect($result->getOrElse('fallback'))->toBe($value);
+    })->with([
+        'empty string' => [''],
+        'zero int' => [0],
+        'zero float' => [0.0],
+        'false' => [false],
+        'empty array' => [[]],
+    ]);
+});
+
 describe('Result::fold', function (): void {
     it('applies onSuccess for Success', function (): void {
         $result = Result::success(42);


### PR DESCRIPTION
# Add `Result::fromNullable()` — convert nullable values into Results

## Why

PHP signals absence with `null` everywhere: repository `find()` methods, `array` lookups via `?? null`, and much of the stdlib. This library already has an exit door from Result to nullable (`getOrNull()`), but no entrance in the other direction — so adopting Result at a boundary means hand-writing the same ternary at every call site:

```php
// Before: repeated at every nullable boundary
$user = $userRepo->find($id);
$result = $user === null
    ? Result::failure('user not found')
    : Result::success($user);

// After: one expression
$result = Result::fromNullable($userRepo->find($id), fn() => 'user not found');
```

A first-class importer makes the boundary conversion one expression, keeps the error lazy, and lets PHPStan subtract `null` from the value type automatically.

## What

- `Result::fromNullable(mixed $value, callable $onNull): Result`
  - `$value === null` → `Failure($onNull())`; otherwise `Success($value)`
  - Only `null` counts as absence — falsy values (`''`, `0`, `false`, `[]`) become Success
  - `$onNull` is invoked exactly once on the null path and never on the non-null path
- PHPStan infers the null-subtracted value type: `?User` input → `Result<User, string>`
- Tests (behavior + type inference), README, and CHANGELOG updated

## Usage

```php
$result = Result::fromNullable($userRepo->find($id), fn() => 'user not found');
// null → Failure('user not found'), non-null → Success(User)
// PHPStan: Result<User, string>
```

## Ecosystem precedent

| Library | API |
|---------|-----|
| kotlin-result | `V?.toResultOr { error }` |
| Rust | `Option::ok_or` / `Option::ok_or_else` |
| phpoption | `Option::fromValue` |
| Scala (cats) | `Either.fromOption` |

## Design notes

- **Callable-only error side (not a `TError|callable` union)**: a union parameter is ambiguous when `E` is itself a callable type, and an eager error value would be constructed on the happy path too. A single `callable(): TError` keeps the error lazy (Rust distinguishes `ok_or` vs `ok_or_else` for exactly this reason; we offer only the lazy form).
- **No `false`-based variant**: a `fromFalse()`-style importer for `strpos()`-like stdlib APIs was considered and deferred until demand is shown, keeping the API surface minimal.
- **Strict `null` check only**: `=== null` avoids surprising behavior for falsy-but-present values like `0` or `''`.
