### PR TITLE
feat: add getOr() and getErrorOr() lazy fallback accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Result::sequence()` for converting a list of Results into one Result with fail-fast semantics, returning the first error unwrapped; throws `ResultException` if any element is not a Result instance
 - Optional `$exceptionClass` parameter for `Result::catch()` to capture only the given exception class (others are rethrown) and narrow the error type
 - `Result::fromNullable()` for converting nullable values into Results with a lazily produced error
+- `getOr()` and `getErrorOr()` for lazy fallbacks computed from the opposite side's value, only invoked when needed
 - `Result::accumulate2()` through `Result::accumulate9()` for combining multiple Result instances with error accumulation
 - `Result::accumulate()` for converting a list of Results into one Result while collecting all errors; throws `ResultException` if any element is not a Result instance
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ $result = $success
 // Get value with default
 $value = $failure->getOrElse(0); // 0
 
+// Get value with lazy fallback computed from the error
+$value = $failure->getOr(fn($error) => strlen($error)); // 13
+// The callback is only invoked on Failure, so expensive defaults are never built on success.
+
 // Catch exceptions
 $result = Result::catch(fn() => riskyOperation());
 
@@ -170,8 +174,10 @@ Use `accumulate($results)` for a homogeneous list of same-typed Results; use `ac
 | `isSuccess()` | Returns true if Success |
 | `isFailure()` | Returns true if Failure |
 | `getOrElse($default)` | Get value or default |
+| `getOr($fn)` | Get value or compute fallback lazily from error |
 | `get()` | Get value or throw |
 | `getErrorOrElse($default)` | Get error or default |
+| `getErrorOr($fn)` | Get error or compute fallback lazily from value |
 | `getError()` | Get error or throw ResultException |
 | `map($fn)` | Transform success value |
 | `mapError($fn)` | Transform error value |

--- a/src/Failure.php
+++ b/src/Failure.php
@@ -64,6 +64,20 @@ final class Failure extends Result
     /**
      * {@inheritDoc}
      *
+     * For Failure, computes the fallback by applying the function to the contained error.
+     *
+     * @template T1
+     * @param callable(E): T1 $fn The fallback function receiving the error value
+     * @return T1 The computed fallback
+     */
+    public function getOr(callable $fn): mixed
+    {
+        return $fn($this->error);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * For Failure, always throws an exception. If the error is a Throwable,
      * it is thrown directly. Otherwise, a ResultException is thrown.
      *
@@ -134,6 +148,20 @@ final class Failure extends Result
      * @return E The contained error value
      */
     public function getErrorOrElse(mixed $default): mixed
+    {
+        return $this->error;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * For Failure, always returns the contained error. The function is not called.
+     *
+     * @template E1
+     * @param callable(T): E1 $fn The fallback function (not called)
+     * @return E The contained error value
+     */
+    public function getErrorOr(callable $fn): mixed
     {
         return $this->error;
     }

--- a/src/Result.php
+++ b/src/Result.php
@@ -530,6 +530,18 @@ abstract class Result
     abstract public function getOrElse(mixed $default): mixed;
 
     /**
+     * Returns the success value, or computes a fallback from the error if this is a Failure.
+     *
+     * Unlike getOrElse(), the fallback is evaluated lazily: the callable is only
+     * invoked for Failure, and it receives the error value to build the fallback.
+     *
+     * @template T1
+     * @param callable(E): T1 $fn The fallback function receiving the error value
+     * @return T|T1 The success value or the computed fallback
+     */
+    abstract public function getOr(callable $fn): mixed;
+
+    /**
      * Returns the success value, or throws an exception if this is a Failure.
      *
      * For Success, returns the contained value. For Failure, throws the error
@@ -589,6 +601,18 @@ abstract class Result
      * @return E|D The error value or the default
      */
     abstract public function getErrorOrElse(mixed $default): mixed;
+
+    /**
+     * Returns the error value, or computes a fallback from the success value if this is a Success.
+     *
+     * Unlike getErrorOrElse(), the fallback is evaluated lazily: the callable is only
+     * invoked for Success, and it receives the success value to build the fallback.
+     *
+     * @template E1
+     * @param callable(T): E1 $fn The fallback function receiving the success value
+     * @return E|E1 The error value or the computed fallback
+     */
+    abstract public function getErrorOr(callable $fn): mixed;
 
     /**
      * Returns the error value, or throws an exception if this is a Success.

--- a/src/Success.php
+++ b/src/Success.php
@@ -64,6 +64,20 @@ final class Success extends Result
     /**
      * {@inheritDoc}
      *
+     * For Success, always returns the contained value. The function is not called.
+     *
+     * @template T1
+     * @param callable(E): T1 $fn The fallback function (not called)
+     * @return T The contained success value
+     */
+    public function getOr(callable $fn): mixed
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * For Success, always returns the contained value without throwing.
      *
      * @return T The contained success value
@@ -129,6 +143,20 @@ final class Success extends Result
     public function getErrorOrElse(mixed $default): mixed
     {
         return $default;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * For Success, computes the fallback by applying the function to the contained value.
+     *
+     * @template E1
+     * @param callable(T): E1 $fn The fallback function receiving the success value
+     * @return E1 The computed fallback
+     */
+    public function getErrorOr(callable $fn): mixed
+    {
+        return $fn($this->value);
     }
 
     /**

--- a/tests/FailureTest.php
+++ b/tests/FailureTest.php
@@ -41,6 +41,36 @@ describe('Failure', function (): void {
         });
     });
 
+    describe('getOr', function (): void {
+        it('computes fallback from error', function (): void {
+            /** @var Failure<int, string> $result */
+            $result = Result::failure('error');
+
+            expect($result->getOr(fn ($e) => strlen($e)))->toBe(5);
+        });
+
+        it('passes error value to callback', function (): void {
+            $captured = null;
+            /** @var Failure<int, string> $result */
+            $result = Result::failure('error message');
+            $value = $result->getOr(function ($e) use (&$captured): int {
+                $captured = $e;
+
+                return 0;
+            });
+
+            expect($value)->toBe(0);
+            expect($captured)->toBe('error message');
+        });
+
+        it('returns null fallback', function (): void {
+            /** @var Failure<int, string> $result */
+            $result = Result::failure('error');
+
+            expect($result->getOr(fn ($e) => null))->toBeNull();
+        });
+    });
+
     describe('get', function (): void {
         it('throws Throwable error', function (): void {
             $exception = new RuntimeException('oops');
@@ -152,6 +182,29 @@ describe('Failure', function (): void {
             $result = Result::failure(null);
 
             expect($result->getErrorOrElse(null))->toBeNull();
+        });
+    });
+
+    describe('getErrorOr', function (): void {
+        it('returns error', function (): void {
+            /** @var Failure<int, string> $result */
+            $result = Result::failure('error message');
+
+            expect($result->getErrorOr(fn ($v) => 'fallback'))->toBe('error message');
+        });
+
+        it('callback is not called', function (): void {
+            $called = false;
+            /** @var Failure<int, string> $result */
+            $result = Result::failure('error');
+            $error = $result->getErrorOr(function ($v) use (&$called): string {
+                $called = true;
+
+                return 'fallback';
+            });
+
+            expect($error)->toBe('error');
+            expect($called)->toBeFalse();
         });
     });
 

--- a/tests/PHPStan/data/result-type-narrowing.php
+++ b/tests/PHPStan/data/result-type-narrowing.php
@@ -278,6 +278,28 @@ function testFallbackMethodsUnionDefaults(Result $result): void
 /**
  * @param Result<int, string> $result
  */
+function testLazyFallbackMethodsUnionCallbackReturnTypes(Result $result): void
+{
+    assertType('bool|int', $result->getOr(fn (string $error): bool => strlen($error) > 0));
+    assertType('RuntimeException|string', $result->getErrorOr(fn (int $value) => new \RuntimeException()));
+}
+
+/**
+ * @param Success<int, string> $success
+ * @param Failure<int, string> $failure
+ */
+function testLazyFallbackMethodsOnConcreteClasses(Success $success, Failure $failure): void
+{
+    assertType('int', $success->getOr(fn (string $error): bool => strlen($error) > 0));
+    assertType('RuntimeException', $success->getErrorOr(fn (int $value) => new \RuntimeException()));
+
+    assertType('bool', $failure->getOr(fn (string $error): bool => strlen($error) > 0));
+    assertType('string', $failure->getErrorOr(fn (int $value) => new \RuntimeException()));
+}
+
+/**
+ * @param Result<int, string> $result
+ */
 function testFoldUnionsCallbackReturnTypes(Result $result): void
 {
     $folded = $result->fold(

--- a/tests/SuccessTest.php
+++ b/tests/SuccessTest.php
@@ -46,6 +46,29 @@ describe('Success', function (): void {
         });
     });
 
+    describe('getOr', function (): void {
+        it('returns value', function (): void {
+            /** @var Success<int, string> $result */
+            $result = Result::success(42);
+
+            expect($result->getOr(fn ($e) => 0))->toBe(42);
+        });
+
+        it('callback is not called', function (): void {
+            $called = false;
+            /** @var Success<int, string> $result */
+            $result = Result::success(42);
+            $value = $result->getOr(function ($e) use (&$called): int {
+                $called = true;
+
+                return 0;
+            });
+
+            expect($value)->toBe(42);
+            expect($called)->toBeFalse();
+        });
+    });
+
     describe('get', function (): void {
         it('returns value', function (): void {
             $result = Result::success(42);
@@ -158,6 +181,22 @@ describe('Success', function (): void {
             $result = Result::success(42);
 
             expect($result->getErrorOrElse(null))->toBeNull();
+        });
+    });
+
+    describe('getErrorOr', function (): void {
+        it('computes fallback from value', function (): void {
+            /** @var Success<int, string> $result */
+            $result = Result::success(42);
+
+            expect($result->getErrorOr(fn ($v) => "no error for $v"))->toBe('no error for 42');
+        });
+
+        it('returns null fallback', function (): void {
+            /** @var Success<int, string> $result */
+            $result = Result::success(42);
+
+            expect($result->getErrorOr(fn ($v) => null))->toBeNull();
         });
     });
 


### PR DESCRIPTION
# Add `getOr()` / `getErrorOr()` — lazy fallback accessors

## Why

`getOrElse($default)` is **eager**: the default is constructed before the call, even when the Result is a Success and the default is thrown away. And the default cannot depend on the error value `E` — reaching it requires a detour through `fold()` or `recover()->get()`.

**Before:**

```php
// Eager: buildDefaultConfig() runs (DB hit, object graph) even on the success path
$config = $result->getOrElse(buildDefaultConfig());

// Fallback needs the error? Awkward detours:
$config = $result->fold(fn($e) => Config::fallbackFor($e), fn($c) => $c);
$config = $result->recover(fn($e) => Config::fallbackFor($e))->get();
```

**After:**

```php
// Lazy: only runs on Failure, and receives the error
$config = $result->getOr(fn($e) => Config::fallbackFor($e));
```

Every major Result/Option implementation ships this eager/lazy pair:

| Library | Eager | Lazy |
|---|---|---|
| Rust | `unwrap_or` | `unwrap_or_else(FnOnce(E) -> T)` — clippy even lints eager misuse via `or_fun_call` |
| Kotlin `Result` | `getOrDefault` | `getOrElse { e -> ... }` |
| kotlin-result | `getOr` | `getOrElse { e -> ... }` |
| Java `Optional` | `orElse` | `orElseGet(Supplier<T>)` — no error arg (Optional has no error channel) |
| Vavr `Try` | `getOrElse` | `getOrElseGet(Function<Throwable, T>)` |
| phpoption | `getOrElse` | `getOrCall(callable)` — no error arg (Option has no error channel) |
| Arrow-kt 2.x | — | `getOrElse((A) -> B)` |

Note the pattern: every type that *has* an error channel (Rust, Kotlin, Vavr, Arrow) passes the error to the lazy callback; only the Option-like types cannot. This implementation follows the former group and passes `E`.

## What

- `getOr(callable $fn)` — Success: returns the value, `$fn` is never invoked. Failure: returns `$fn($error)`. Signature: `@template T1` / `@param callable(E): T1` / `@return T|T1`.
- `getErrorOr(callable $fn)` — symmetric, matching the existing `getOrElse`/`getErrorOrElse` symmetry: Failure returns the error, Success returns `$fn($value)`. Signature: `@template E1` / `@param callable(T): E1` / `@return E|E1`.
- Pest tests (lazy short-circuit asserted via side-effect flags, error value passed to callback, null fallbacks), PHPStan `assertType` coverage for the `T|T1` / `E|E1` unions and concrete-class inference, README and CHANGELOG updates.

## Usage

```php
$value = $failure->getOr(fn($error) => strlen($error));
// Failure('error message') -> 13; on Success the callback never runs
```

PHPStan infers the precise union: `Result<int, string>` + a `bool`-returning callback yields `bool|int`.

## Design notes

- **Why a separate method instead of overloading `getOrElse`** — PHP has no signature-based overloading, and an `is_callable()` runtime switch is unsound: plain strings like `'date'` are callable, so `Result<string, E>` defaults would be misdispatched, and a default for `Result<Closure, E>` becomes inexpressible. Java deliberately split `orElse`/`orElseGet` for the same ambiguity reason even though Java supports overloading.
- **Name: `getOr`** — reads as the concise lazy sibling of `getOrElse`: "get, or compute this". The dedicated `callable` native signature keeps the two forms unambiguous at both runtime and PHPStan level. Trade-off acknowledged: kotlin-result uses `getOr(default)` for its *eager* form; here the eager form is the already-published `getOrElse($default)`, so the short name was available for the lazy form.
- **Rejected: `getOrElseGet` (Vavr `Try.getOrElseGet(Function<Throwable, T>)`) / `getOrCall` (phpoption)** — both are precedented, but the extra suffix adds length without adding information once the parameter type already states "callable"; `getOrCall` additionally hides that the callback receives the error.
- **Rejected: relying on `fold()`/`recover()->get()`** — both work but bury the intent (a no-op identity lambda, or an intermediate `Success` allocation plus a throwing accessor) for what is the single most common terminal operation on a Result.
